### PR TITLE
kyber/avx2: fix makefiles

### DIFF
--- a/src/crypto_kem/kyber/kyber512/amd64/avx2/Makefile
+++ b/src/crypto_kem/kyber/kyber512/amd64/avx2/Makefile
@@ -1,4 +1,4 @@
 SRCS := kem.jazz
-JFLAGS := -lea
+override JFLAGS += -lea
 include ../../../../../Makefile.common
 

--- a/src/crypto_kem/kyber/kyber768/amd64/avx2/Makefile
+++ b/src/crypto_kem/kyber/kyber768/amd64/avx2/Makefile
@@ -1,4 +1,4 @@
 SRCS := kem.jazz
-JFLAGS := -lea
+override JFLAGS += -lea
 include ../../../../../Makefile.common
 

--- a/src/crypto_secretbox/xsalsa20poly1305/amd64/avx/Makefile
+++ b/src/crypto_secretbox/xsalsa20poly1305/amd64/avx/Makefile
@@ -1,3 +1,3 @@
-JFLAGS := ${JFLAGS} -lazy-regalloc
+override JFLAGS += -lazy-regalloc
 SRCS := secretbox.jazz
 include ../../../../Makefile.common

--- a/src/crypto_secretbox/xsalsa20poly1305/amd64/avx2/Makefile
+++ b/src/crypto_secretbox/xsalsa20poly1305/amd64/avx2/Makefile
@@ -1,3 +1,3 @@
-JFLAGS := ${JFLAGS} -lazy-regalloc
+override JFLAGS += -lazy-regalloc
 SRCS := secretbox.jazz
 include ../../../../Makefile.common

--- a/src/crypto_stream/chacha/common/amd64/avx/Flags.mk
+++ b/src/crypto_stream/chacha/common/amd64/avx/Flags.mk
@@ -1,1 +1,1 @@
-JFLAGS := ${JFLAGS} -lazy-regalloc
+override JFLAGS += -lazy-regalloc

--- a/src/crypto_stream/chacha/common/amd64/avx2/Flags.mk
+++ b/src/crypto_stream/chacha/common/amd64/avx2/Flags.mk
@@ -1,1 +1,1 @@
-JFLAGS := ${JFLAGS} -lazy-regalloc
+override JFLAGS += -lazy-regalloc

--- a/src/crypto_stream/salsa20/common/amd64/avx/Flags.mk
+++ b/src/crypto_stream/salsa20/common/amd64/avx/Flags.mk
@@ -1,1 +1,1 @@
-JFLAGS := ${JFLAGS} -lazy-regalloc
+override JFLAGS += -lazy-regalloc

--- a/src/crypto_stream/salsa20/common/amd64/avx2/Flags.mk
+++ b/src/crypto_stream/salsa20/common/amd64/avx2/Flags.mk
@@ -1,1 +1,1 @@
-JFLAGS := ${JFLAGS} -lazy-regalloc
+override JFLAGS += -lazy-regalloc


### PR DESCRIPTION
Otherwise, calling `make JFLAGS=-intel` (or any other useful switch) breaks compilation.