### PR TITLE
onetimeauth: make compatible with MS-x64 call-convention

### DIFF
--- a/src/crypto_onetimeauth/poly1305/amd64/avx/onetimeauth.jazz
+++ b/src/crypto_onetimeauth/poly1305/amd64/avx/onetimeauth.jazz
@@ -1,9 +1,11 @@
 require "poly1305.jinc"
 
-export fn jade_onetimeauth_poly1305_amd64_avx(reg u64 out in _inlen _key) -> reg u64
+export fn jade_onetimeauth_poly1305_amd64_avx(reg u64 _out _in _inlen _key) -> reg u64
 {
-  reg u64 r inlen key;
+  reg u64 r out in inlen key;
 
+  out = _out;
+  in = _in;
   inlen = _inlen;
   key = _key;
   __poly1305_avx(out, in, inlen, key);
@@ -11,10 +13,12 @@ export fn jade_onetimeauth_poly1305_amd64_avx(reg u64 out in _inlen _key) -> reg
   return r;
 }
 
-export fn jade_onetimeauth_poly1305_amd64_avx_verify(reg u64 h in _inlen _key) -> reg u64
+export fn jade_onetimeauth_poly1305_amd64_avx_verify(reg u64 _h _in _inlen _key) -> reg u64
 {
-  reg u64 r inlen key;
+  reg u64 r h in inlen key;
 
+  h = _h;
+  in = _in;
   inlen = _inlen;
   key = _key;
   r = __poly1305_verify_avx(h, in, inlen, key);

--- a/src/crypto_onetimeauth/poly1305/amd64/avx2/onetimeauth.jazz
+++ b/src/crypto_onetimeauth/poly1305/amd64/avx2/onetimeauth.jazz
@@ -1,9 +1,11 @@
 require "poly1305.jinc"
 
-export fn jade_onetimeauth_poly1305_amd64_avx2(reg u64 out in _inlen _key) -> reg u64
+export fn jade_onetimeauth_poly1305_amd64_avx2(reg u64 _out _in _inlen _key) -> reg u64
 {
-  reg u64 r inlen key;
+  reg u64 r out in inlen key;
 
+  out = _out;
+  in = _in;
   inlen = _inlen;
   key = _key;
   __poly1305_avx2(out, in, inlen, key);
@@ -11,10 +13,12 @@ export fn jade_onetimeauth_poly1305_amd64_avx2(reg u64 out in _inlen _key) -> re
   return r;
 }
 
-export fn jade_onetimeauth_poly1305_amd64_avx2_verify(reg u64 h in _inlen _key) -> reg u64
+export fn jade_onetimeauth_poly1305_amd64_avx2_verify(reg u64 _h _in _inlen _key) -> reg u64
 {
-  reg u64 r inlen key;
+  reg u64 r h in inlen key;
 
+  h = _h;
+  in = _in;
   inlen = _inlen;
   key = _key;
   r = __poly1305_verify_avx2(h, in, inlen, key);

--- a/src/crypto_onetimeauth/poly1305/amd64/ref/onetimeauth.jazz
+++ b/src/crypto_onetimeauth/poly1305/amd64/ref/onetimeauth.jazz
@@ -1,9 +1,11 @@
 require "poly1305.jinc"
 
-export fn jade_onetimeauth_poly1305_amd64_ref(reg u64 out in _inlen _key) -> reg u64
+export fn jade_onetimeauth_poly1305_amd64_ref(reg u64 _out _in _inlen _key) -> reg u64
 {
-  reg u64 r inlen key;
+  reg u64 r out in inlen key;
 
+  out = _out;
+  in = _in;
   inlen = _inlen;
   key = _key;
   __poly1305_ref(out, in, inlen, key);
@@ -11,10 +13,12 @@ export fn jade_onetimeauth_poly1305_amd64_ref(reg u64 out in _inlen _key) -> reg
   return r;
 }
 
-export fn jade_onetimeauth_poly1305_amd64_ref_verify(reg u64 h in _inlen _key) -> reg u64
+export fn jade_onetimeauth_poly1305_amd64_ref_verify(reg u64 _h _in _inlen _key) -> reg u64
 {
-  reg u64 r inlen key;
+  reg u64 r h in inlen key;
 
+  h = _h;
+  in = _in;
   inlen = _inlen;
   key = _key;
   r = __poly1305_verify_ref(h, in, inlen, key);


### PR DESCRIPTION
Renaming the arguments to export functions allow to free the registers
that are used for parameter passing for later use (RCX is used in shifts
and RDX in multiplications).