### PR TITLE
Add annotation for compatibility with Jasmin 2022.09

### DIFF
--- a/src/crypto_kem/kyber/common/amd64/ref/poly.jinc
+++ b/src/crypto_kem/kyber/common/amd64/ref/poly.jinc
@@ -553,6 +553,7 @@ fn __poly_cbd_eta2(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_ETA2*KYBER_N/4] buf
 }
 
 
+#[returnaddress=stack]
 fn _poly_getnoise_eta1(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_SYMBYTES] seed, reg u8 nonce) -> reg ptr u16[KYBER_N]
 {
   stack ptr u16[KYBER_N] s_rp;


### PR DESCRIPTION
This annotation should have no effect with current development branch of Jasmin: passing return-address on the stack is the default behavior.