### PR TITLE
Add NIST KAT testing from liboqs

### DIFF
--- a/src/crypto_kem/kyber/kyber512/META.yml
+++ b/src/crypto_kem/kyber/kyber512/META.yml
@@ -2,9 +2,7 @@ name: Kyber512
 type: kem
 checksumsmall: 9c1a84c0573d21b5fb50ff68f015c19206cebbda4aa3caa6f9ba4b167eea9514
 checksumbig: 4596232083e3da10d341576afbc59b24a520073e985a9b9df2d587e67e926a7b
-
-# TODO: replace me
-nistkat: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+nistkat: bb0481d3325d828817900b709d23917cefbc10026fc857f098979451f67bb0ca
 
 claimed-nist-level: 1
 claimed-security: IND-CCA2

--- a/src/crypto_kem/kyber/kyber768/META.yml
+++ b/src/crypto_kem/kyber/kyber768/META.yml
@@ -2,9 +2,7 @@ name: Kyber768
 type: kem
 checksumsmall: 456bb24a767160dcca466adde267b87f359de6e827d31b5b23512d227d8bbfaa
 checksumbig: 8004a42f34a4125acb4f88628139576882cdf9502a77937003e34f52d217a730
-
-# TODO: replace me
-nistkat: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+nistkat: 89e82a5bf2d4ddb2c6444e10409e6d9ca65dafbca67d1a0db2c9b54920a29172
 
 claimed-nist-level: 3
 claimed-security: IND-CCA2

--- a/test/Makefile
+++ b/test/Makefile
@@ -65,6 +65,7 @@ COMMON   := common
 
 EXT      := ../ext
 RANDSRC  := $(COMMON)/notrandombytes.c
+NIST_RANDSRC := $(COMMON)/nistkatrng.c
 
 FILTER   ?= $(SRC)/crypto_%
 export FILTER
@@ -112,8 +113,10 @@ DEFINE     ?=
 DNAMESPACES = -DJADE_NAMESPACE=$(NAMESPACE1) -DJADE_NAMESPACE_LC=$(NAMESPACE)
 INCLUDES    = -I$(IDIR)/include/ -I$(COMMON)/ -Iinclude/
 PRINT       = common/print.c
+AES			= $(COMMON)/aes.c
 COMPILE     = $(CC) $(CFLAGS) -o $@ $(DEFINE) $(DNAMESPACES) $(INCLUDES) crypto_$(OPERATION)/$(@F).c $(PRINT) $(ASM) $(RANDSRC) $(CIL)
 COMPILE_P   = $(CC) $(CFLAGS) -o $@ $(DEFINE) $(DNAMESPACES) $(INCLUDES) crypto_$(OPERATION)/$(@F).c $(PRINT)        $(RANDSRC) $(CIL)
+COMPILE_NIST = $(CC) $(CFLAGS) -o $@ $(DEFINE) $(DNAMESPACES) $(INCLUDES) crypto_$(OPERATION)/$(@F).c $(PRINT) $(ASM) $(NIST_RANDSRC) $(AES) $(CIL)
 
 # --------------------------------------------------------------------
 .PHONY: __phony default main
@@ -162,7 +165,7 @@ include Makefile.partial_implementations
 %/nistkat: __phony | %/ %/$(CID)
 	$(MAKE) -C $(IDIR) || true
 	$(CIC)
-	$(COMPILE) || true
+	$(COMPILE_NIST) || true
 
 # --------------------------------------------------------------------
 $(OUT):

--- a/test/common/aes.c
+++ b/test/common/aes.c
@@ -1,0 +1,639 @@
+/*
+ * AES implementation based on code from BearSSL (https://bearssl.org/)
+ * by Thomas Pornin. Taken from PQClean.
+ *
+ *
+ * Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "aes.h"
+
+static inline uint32_t br_dec32le(const unsigned char *src) {
+    return (uint32_t)src[0]
+           | ((uint32_t)src[1] << 8)
+           | ((uint32_t)src[2] << 16)
+           | ((uint32_t)src[3] << 24);
+}
+
+static void br_range_dec32le(uint32_t *v, size_t num, const unsigned char *src) {
+    while (num-- > 0) {
+        *v ++ = br_dec32le(src);
+        src += 4;
+    }
+}
+
+static inline uint32_t br_swap32(uint32_t x) {
+    x = ((x & (uint32_t)0x00FF00FF) << 8)
+        | ((x >> 8) & (uint32_t)0x00FF00FF);
+    return (x << 16) | (x >> 16);
+}
+
+static inline void br_enc32le(unsigned char *dst, uint32_t x) {
+    dst[0] = (unsigned char)x;
+    dst[1] = (unsigned char)(x >> 8);
+    dst[2] = (unsigned char)(x >> 16);
+    dst[3] = (unsigned char)(x >> 24);
+}
+
+static void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num) {
+    while (num-- > 0) {
+        br_enc32le(dst, *v ++);
+        dst += 4;
+    }
+}
+
+static void br_aes_ct64_bitslice_Sbox(uint64_t *q) {
+    /*
+     * This S-box implementation is a straightforward translation of
+     * the circuit described by Boyar and Peralta in "A new
+     * combinational logic minimization technique with applications
+     * to cryptology" (https://eprint.iacr.org/2009/191.pdf).
+     *
+     * Note that variables x* (input) and s* (output) are numbered
+     * in "reverse" order (x0 is the high bit, x7 is the low bit).
+     */
+
+    uint64_t x0, x1, x2, x3, x4, x5, x6, x7;
+    uint64_t y1, y2, y3, y4, y5, y6, y7, y8, y9;
+    uint64_t y10, y11, y12, y13, y14, y15, y16, y17, y18, y19;
+    uint64_t y20, y21;
+    uint64_t z0, z1, z2, z3, z4, z5, z6, z7, z8, z9;
+    uint64_t z10, z11, z12, z13, z14, z15, z16, z17;
+    uint64_t t0, t1, t2, t3, t4, t5, t6, t7, t8, t9;
+    uint64_t t10, t11, t12, t13, t14, t15, t16, t17, t18, t19;
+    uint64_t t20, t21, t22, t23, t24, t25, t26, t27, t28, t29;
+    uint64_t t30, t31, t32, t33, t34, t35, t36, t37, t38, t39;
+    uint64_t t40, t41, t42, t43, t44, t45, t46, t47, t48, t49;
+    uint64_t t50, t51, t52, t53, t54, t55, t56, t57, t58, t59;
+    uint64_t t60, t61, t62, t63, t64, t65, t66, t67;
+    uint64_t s0, s1, s2, s3, s4, s5, s6, s7;
+
+    x0 = q[7];
+    x1 = q[6];
+    x2 = q[5];
+    x3 = q[4];
+    x4 = q[3];
+    x5 = q[2];
+    x6 = q[1];
+    x7 = q[0];
+
+    /*
+     * Top linear transformation.
+     */
+    y14 = x3 ^ x5;
+    y13 = x0 ^ x6;
+    y9 = x0 ^ x3;
+    y8 = x0 ^ x5;
+    t0 = x1 ^ x2;
+    y1 = t0 ^ x7;
+    y4 = y1 ^ x3;
+    y12 = y13 ^ y14;
+    y2 = y1 ^ x0;
+    y5 = y1 ^ x6;
+    y3 = y5 ^ y8;
+    t1 = x4 ^ y12;
+    y15 = t1 ^ x5;
+    y20 = t1 ^ x1;
+    y6 = y15 ^ x7;
+    y10 = y15 ^ t0;
+    y11 = y20 ^ y9;
+    y7 = x7 ^ y11;
+    y17 = y10 ^ y11;
+    y19 = y10 ^ y8;
+    y16 = t0 ^ y11;
+    y21 = y13 ^ y16;
+    y18 = x0 ^ y16;
+
+    /*
+     * Non-linear section.
+     */
+    t2 = y12 & y15;
+    t3 = y3 & y6;
+    t4 = t3 ^ t2;
+    t5 = y4 & x7;
+    t6 = t5 ^ t2;
+    t7 = y13 & y16;
+    t8 = y5 & y1;
+    t9 = t8 ^ t7;
+    t10 = y2 & y7;
+    t11 = t10 ^ t7;
+    t12 = y9 & y11;
+    t13 = y14 & y17;
+    t14 = t13 ^ t12;
+    t15 = y8 & y10;
+    t16 = t15 ^ t12;
+    t17 = t4 ^ t14;
+    t18 = t6 ^ t16;
+    t19 = t9 ^ t14;
+    t20 = t11 ^ t16;
+    t21 = t17 ^ y20;
+    t22 = t18 ^ y19;
+    t23 = t19 ^ y21;
+    t24 = t20 ^ y18;
+
+    t25 = t21 ^ t22;
+    t26 = t21 & t23;
+    t27 = t24 ^ t26;
+    t28 = t25 & t27;
+    t29 = t28 ^ t22;
+    t30 = t23 ^ t24;
+    t31 = t22 ^ t26;
+    t32 = t31 & t30;
+    t33 = t32 ^ t24;
+    t34 = t23 ^ t33;
+    t35 = t27 ^ t33;
+    t36 = t24 & t35;
+    t37 = t36 ^ t34;
+    t38 = t27 ^ t36;
+    t39 = t29 & t38;
+    t40 = t25 ^ t39;
+
+    t41 = t40 ^ t37;
+    t42 = t29 ^ t33;
+    t43 = t29 ^ t40;
+    t44 = t33 ^ t37;
+    t45 = t42 ^ t41;
+    z0 = t44 & y15;
+    z1 = t37 & y6;
+    z2 = t33 & x7;
+    z3 = t43 & y16;
+    z4 = t40 & y1;
+    z5 = t29 & y7;
+    z6 = t42 & y11;
+    z7 = t45 & y17;
+    z8 = t41 & y10;
+    z9 = t44 & y12;
+    z10 = t37 & y3;
+    z11 = t33 & y4;
+    z12 = t43 & y13;
+    z13 = t40 & y5;
+    z14 = t29 & y2;
+    z15 = t42 & y9;
+    z16 = t45 & y14;
+    z17 = t41 & y8;
+
+    /*
+     * Bottom linear transformation.
+     */
+    t46 = z15 ^ z16;
+    t47 = z10 ^ z11;
+    t48 = z5 ^ z13;
+    t49 = z9 ^ z10;
+    t50 = z2 ^ z12;
+    t51 = z2 ^ z5;
+    t52 = z7 ^ z8;
+    t53 = z0 ^ z3;
+    t54 = z6 ^ z7;
+    t55 = z16 ^ z17;
+    t56 = z12 ^ t48;
+    t57 = t50 ^ t53;
+    t58 = z4 ^ t46;
+    t59 = z3 ^ t54;
+    t60 = t46 ^ t57;
+    t61 = z14 ^ t57;
+    t62 = t52 ^ t58;
+    t63 = t49 ^ t58;
+    t64 = z4 ^ t59;
+    t65 = t61 ^ t62;
+    t66 = z1 ^ t63;
+    s0 = t59 ^ t63;
+    s6 = t56 ^ ~t62;
+    s7 = t48 ^ ~t60;
+    t67 = t64 ^ t65;
+    s3 = t53 ^ t66;
+    s4 = t51 ^ t66;
+    s5 = t47 ^ t65;
+    s1 = t64 ^ ~s3;
+    s2 = t55 ^ ~t67;
+
+    q[7] = s0;
+    q[6] = s1;
+    q[5] = s2;
+    q[4] = s3;
+    q[3] = s4;
+    q[2] = s5;
+    q[1] = s6;
+    q[0] = s7;
+}
+
+static void br_aes_ct64_ortho(uint64_t *q) {
+#define SWAPN(cl, ch, s, x, y)   do { \
+        uint64_t a, b; \
+        a = (x); \
+        b = (y); \
+        (x) = (a & (uint64_t)(cl)) | ((b & (uint64_t)(cl)) << (s)); \
+        (y) = ((a & (uint64_t)(ch)) >> (s)) | (b & (uint64_t)(ch)); \
+    } while (0)
+
+#define SWAP2(x, y)    SWAPN(0x5555555555555555, 0xAAAAAAAAAAAAAAAA,  1, x, y)
+#define SWAP4(x, y)    SWAPN(0x3333333333333333, 0xCCCCCCCCCCCCCCCC,  2, x, y)
+#define SWAP8(x, y)    SWAPN(0x0F0F0F0F0F0F0F0F, 0xF0F0F0F0F0F0F0F0,  4, x, y)
+
+    SWAP2(q[0], q[1]);
+    SWAP2(q[2], q[3]);
+    SWAP2(q[4], q[5]);
+    SWAP2(q[6], q[7]);
+
+    SWAP4(q[0], q[2]);
+    SWAP4(q[1], q[3]);
+    SWAP4(q[4], q[6]);
+    SWAP4(q[5], q[7]);
+
+    SWAP8(q[0], q[4]);
+    SWAP8(q[1], q[5]);
+    SWAP8(q[2], q[6]);
+    SWAP8(q[3], q[7]);
+}
+
+static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t *w) {
+    uint64_t x0, x1, x2, x3;
+
+    x0 = w[0];
+    x1 = w[1];
+    x2 = w[2];
+    x3 = w[3];
+    x0 |= (x0 << 16);
+    x1 |= (x1 << 16);
+    x2 |= (x2 << 16);
+    x3 |= (x3 << 16);
+    x0 &= (uint64_t)0x0000FFFF0000FFFF;
+    x1 &= (uint64_t)0x0000FFFF0000FFFF;
+    x2 &= (uint64_t)0x0000FFFF0000FFFF;
+    x3 &= (uint64_t)0x0000FFFF0000FFFF;
+    x0 |= (x0 << 8);
+    x1 |= (x1 << 8);
+    x2 |= (x2 << 8);
+    x3 |= (x3 << 8);
+    x0 &= (uint64_t)0x00FF00FF00FF00FF;
+    x1 &= (uint64_t)0x00FF00FF00FF00FF;
+    x2 &= (uint64_t)0x00FF00FF00FF00FF;
+    x3 &= (uint64_t)0x00FF00FF00FF00FF;
+    *q0 = x0 | (x2 << 8);
+    *q1 = x1 | (x3 << 8);
+}
+
+static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1) {
+    uint64_t x0, x1, x2, x3;
+
+    x0 = q0 & (uint64_t)0x00FF00FF00FF00FF;
+    x1 = q1 & (uint64_t)0x00FF00FF00FF00FF;
+    x2 = (q0 >> 8) & (uint64_t)0x00FF00FF00FF00FF;
+    x3 = (q1 >> 8) & (uint64_t)0x00FF00FF00FF00FF;
+    x0 |= (x0 >> 8);
+    x1 |= (x1 >> 8);
+    x2 |= (x2 >> 8);
+    x3 |= (x3 >> 8);
+    x0 &= (uint64_t)0x0000FFFF0000FFFF;
+    x1 &= (uint64_t)0x0000FFFF0000FFFF;
+    x2 &= (uint64_t)0x0000FFFF0000FFFF;
+    x3 &= (uint64_t)0x0000FFFF0000FFFF;
+    w[0] = (uint32_t)x0 | (uint32_t)(x0 >> 16);
+    w[1] = (uint32_t)x1 | (uint32_t)(x1 >> 16);
+    w[2] = (uint32_t)x2 | (uint32_t)(x2 >> 16);
+    w[3] = (uint32_t)x3 | (uint32_t)(x3 >> 16);
+}
+
+static const unsigned char Rcon[] = {
+    0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36
+};
+
+static uint32_t sub_word(uint32_t x) {
+    uint64_t q[8];
+
+    memset(q, 0, sizeof q);
+    q[0] = x;
+    br_aes_ct64_ortho(q);
+    br_aes_ct64_bitslice_Sbox(q);
+    br_aes_ct64_ortho(q);
+    return (uint32_t)q[0];
+}
+
+static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key, unsigned int key_len) {
+    unsigned int i, j, k, nk, nkf;
+    uint32_t tmp;
+    uint32_t skey[60];
+    unsigned nrounds = 10 + ((key_len - 16) >> 2);
+
+    nk = (key_len >> 2);
+    nkf = ((nrounds + 1) << 2);
+    br_range_dec32le(skey, (key_len >> 2), key);
+    tmp = skey[(key_len >> 2) - 1];
+    for (i = nk, j = 0, k = 0; i < nkf; i ++) {
+        if (j == 0) {
+            tmp = (tmp << 24) | (tmp >> 8);
+            tmp = sub_word(tmp) ^ Rcon[k];
+        } else if (nk > 6 && j == 4) {
+            tmp = sub_word(tmp);
+        }
+        tmp ^= skey[i - nk];
+        skey[i] = tmp;
+        if (++ j == nk) {
+            j = 0;
+            k ++;
+        }
+    }
+
+    for (i = 0, j = 0; i < nkf; i += 4, j += 2) {
+        uint64_t q[8];
+
+        br_aes_ct64_interleave_in(&q[0], &q[4], skey + i);
+        q[1] = q[0];
+        q[2] = q[0];
+        q[3] = q[0];
+        q[5] = q[4];
+        q[6] = q[4];
+        q[7] = q[4];
+        br_aes_ct64_ortho(q);
+        comp_skey[j + 0] =
+            (q[0] & (uint64_t)0x1111111111111111)
+            | (q[1] & (uint64_t)0x2222222222222222)
+            | (q[2] & (uint64_t)0x4444444444444444)
+            | (q[3] & (uint64_t)0x8888888888888888);
+        comp_skey[j + 1] =
+            (q[4] & (uint64_t)0x1111111111111111)
+            | (q[5] & (uint64_t)0x2222222222222222)
+            | (q[6] & (uint64_t)0x4444444444444444)
+            | (q[7] & (uint64_t)0x8888888888888888);
+    }
+}
+
+static void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey, unsigned int nrounds) {
+    unsigned u, v, n;
+
+    n = (nrounds + 1) << 1;
+    for (u = 0, v = 0; u < n; u ++, v += 4) {
+        uint64_t x0, x1, x2, x3;
+
+        x0 = x1 = x2 = x3 = comp_skey[u];
+        x0 &= (uint64_t)0x1111111111111111;
+        x1 &= (uint64_t)0x2222222222222222;
+        x2 &= (uint64_t)0x4444444444444444;
+        x3 &= (uint64_t)0x8888888888888888;
+        x1 >>= 1;
+        x2 >>= 2;
+        x3 >>= 3;
+        skey[v + 0] = (x0 << 4) - x0;
+        skey[v + 1] = (x1 << 4) - x1;
+        skey[v + 2] = (x2 << 4) - x2;
+        skey[v + 3] = (x3 << 4) - x3;
+    }
+}
+
+static inline void add_round_key(uint64_t *q, const uint64_t *sk) {
+    q[0] ^= sk[0];
+    q[1] ^= sk[1];
+    q[2] ^= sk[2];
+    q[3] ^= sk[3];
+    q[4] ^= sk[4];
+    q[5] ^= sk[5];
+    q[6] ^= sk[6];
+    q[7] ^= sk[7];
+}
+
+static inline void shift_rows(uint64_t *q) {
+    int i;
+
+    for (i = 0; i < 8; i ++) {
+        uint64_t x;
+
+        x = q[i];
+        q[i] = (x & (uint64_t)0x000000000000FFFF)
+               | ((x & (uint64_t)0x00000000FFF00000) >> 4)
+               | ((x & (uint64_t)0x00000000000F0000) << 12)
+               | ((x & (uint64_t)0x0000FF0000000000) >> 8)
+               | ((x & (uint64_t)0x000000FF00000000) << 8)
+               | ((x & (uint64_t)0xF000000000000000) >> 12)
+               | ((x & (uint64_t)0x0FFF000000000000) << 4);
+    }
+}
+
+static inline uint64_t rotr32(uint64_t x) {
+    return (x << 32) | (x >> 32);
+}
+
+static inline void mix_columns(uint64_t *q) {
+    uint64_t q0, q1, q2, q3, q4, q5, q6, q7;
+    uint64_t r0, r1, r2, r3, r4, r5, r6, r7;
+
+    q0 = q[0];
+    q1 = q[1];
+    q2 = q[2];
+    q3 = q[3];
+    q4 = q[4];
+    q5 = q[5];
+    q6 = q[6];
+    q7 = q[7];
+    r0 = (q0 >> 16) | (q0 << 48);
+    r1 = (q1 >> 16) | (q1 << 48);
+    r2 = (q2 >> 16) | (q2 << 48);
+    r3 = (q3 >> 16) | (q3 << 48);
+    r4 = (q4 >> 16) | (q4 << 48);
+    r5 = (q5 >> 16) | (q5 << 48);
+    r6 = (q6 >> 16) | (q6 << 48);
+    r7 = (q7 >> 16) | (q7 << 48);
+
+    q[0] = q7 ^ r7 ^ r0 ^ rotr32(q0 ^ r0);
+    q[1] = q0 ^ r0 ^ q7 ^ r7 ^ r1 ^ rotr32(q1 ^ r1);
+    q[2] = q1 ^ r1 ^ r2 ^ rotr32(q2 ^ r2);
+    q[3] = q2 ^ r2 ^ q7 ^ r7 ^ r3 ^ rotr32(q3 ^ r3);
+    q[4] = q3 ^ r3 ^ q7 ^ r7 ^ r4 ^ rotr32(q4 ^ r4);
+    q[5] = q4 ^ r4 ^ r5 ^ rotr32(q5 ^ r5);
+    q[6] = q5 ^ r5 ^ r6 ^ rotr32(q6 ^ r6);
+    q[7] = q6 ^ r6 ^ r7 ^ rotr32(q7 ^ r7);
+}
+
+static void inc4_be(uint32_t *x) {
+    uint32_t t = br_swap32(*x) + 4;
+    *x = br_swap32(t);
+}
+
+static void aes_ecb4x(unsigned char out[64], const uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds) {
+    uint32_t w[16];
+    uint64_t q[8];
+    unsigned int i;
+
+    memcpy(w, ivw, sizeof(w));
+    for (i = 0; i < 4; i++) {
+        br_aes_ct64_interleave_in(&q[i], &q[i + 4], w + (i << 2));
+    }
+    br_aes_ct64_ortho(q);
+
+    add_round_key(q, sk_exp);
+    for (i = 1; i < nrounds; i++) {
+        br_aes_ct64_bitslice_Sbox(q);
+        shift_rows(q);
+        mix_columns(q);
+        add_round_key(q, sk_exp + (i << 3));
+    }
+    br_aes_ct64_bitslice_Sbox(q);
+    shift_rows(q);
+    add_round_key(q, sk_exp + 8 * nrounds);
+
+    br_aes_ct64_ortho(q);
+    for (i = 0; i < 4; i ++) {
+        br_aes_ct64_interleave_out(w + (i << 2), q[i], q[i + 4]);
+    }
+    br_range_enc32le(out, w, 16);
+}
+
+static void aes_ctr4x(unsigned char out[64], uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds) {
+    aes_ecb4x(out, ivw, sk_exp, nrounds);
+
+    /* Increase counter for next 4 blocks */
+    inc4_be(ivw + 3);
+    inc4_be(ivw + 7);
+    inc4_be(ivw + 11);
+    inc4_be(ivw + 15);
+}
+
+static void aes_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const uint64_t *rkeys, unsigned int nrounds) {
+    uint32_t blocks[16];
+    unsigned char t[64];
+
+    while (nblocks >= 4) {
+        br_range_dec32le(blocks, 16, in);
+        aes_ecb4x(out, blocks, rkeys, nrounds);
+        nblocks -= 4;
+        in += 64;
+        out += 64;
+    }
+
+    if (nblocks) {
+        br_range_dec32le(blocks, nblocks * 4, in);
+        aes_ecb4x(t, blocks, rkeys, nrounds);
+        memcpy(out, t, nblocks * 16);
+    }
+}
+
+static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const uint64_t *rkeys, unsigned int nrounds) {
+    uint32_t ivw[16];
+    size_t i;
+    uint32_t cc = 0;
+
+    br_range_dec32le(ivw, 3, iv);
+    memcpy(ivw +  4, ivw, 3 * sizeof(uint32_t));
+    memcpy(ivw +  8, ivw, 3 * sizeof(uint32_t));
+    memcpy(ivw + 12, ivw, 3 * sizeof(uint32_t));
+    ivw[ 3] = br_swap32(cc);
+    ivw[ 7] = br_swap32(cc + 1);
+    ivw[11] = br_swap32(cc + 2);
+    ivw[15] = br_swap32(cc + 3);
+
+    while (outlen > 64) {
+        aes_ctr4x(out, ivw, rkeys, nrounds);
+        out += 64;
+        outlen -= 64;
+    }
+    if (outlen > 0) {
+        unsigned char tmp[64];
+        aes_ctr4x(tmp, ivw, rkeys, nrounds);
+        for (i = 0; i < outlen; i++) {
+            out[i] = tmp[i];
+        }
+    }
+}
+
+void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key) {
+    uint64_t skey[22];
+
+    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES128_STATESIZE);
+    if (r->sk_exp == NULL) {
+        exit(111);
+    }
+
+    br_aes_ct64_keysched(skey, key, 16);
+    br_aes_ct64_skey_expand(r->sk_exp, skey, 10);
+}
+
+void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key) {
+    aes128_ecb_keyexp(r, key);
+}
+
+void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key) {
+    uint64_t skey[26];
+    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES192_STATESIZE);
+    if (r->sk_exp == NULL) {
+        exit(111);
+    }
+
+    br_aes_ct64_keysched(skey, key, 24);
+    br_aes_ct64_skey_expand(r->sk_exp, skey, 12);
+}
+
+void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key) {
+    aes192_ecb_keyexp(r, key);
+}
+
+void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key) {
+    uint64_t skey[30];
+    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES256_STATESIZE);
+    if (r->sk_exp == NULL) {
+        exit(111);
+    }
+
+    br_aes_ct64_keysched(skey, key, 32);
+    br_aes_ct64_skey_expand(r->sk_exp, skey, 14);
+}
+
+void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key) {
+    aes256_ecb_keyexp(r, key);
+}
+
+void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes128ctx *ctx) {
+    aes_ecb(out, in, nblocks, ctx->sk_exp, 10);
+}
+
+void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes128ctx *ctx) {
+    aes_ctr(out, outlen, iv, ctx->sk_exp, 10);
+}
+
+void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes192ctx *ctx) {
+    aes_ecb(out, in, nblocks, ctx->sk_exp, 12);
+}
+
+void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes192ctx *ctx) {
+    aes_ctr(out, outlen, iv, ctx->sk_exp, 12);
+}
+
+void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes256ctx *ctx) {
+    aes_ecb(out, in, nblocks, ctx->sk_exp, 14);
+}
+
+void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes256ctx *ctx) {
+    aes_ctr(out, outlen, iv, ctx->sk_exp, 14);
+}
+
+void aes128_ctx_release(aes128ctx *r) {
+    free(r->sk_exp);
+}
+
+void aes192_ctx_release(aes192ctx *r) {
+    free(r->sk_exp);
+}
+
+void aes256_ctx_release(aes256ctx *r) {
+    free(r->sk_exp);
+}

--- a/test/common/aes.h
+++ b/test/common/aes.h
@@ -1,0 +1,66 @@
+#ifndef AES_H
+#define AES_H
+
+//Taken from PQClean
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define AES128_KEYBYTES 16
+#define AES192_KEYBYTES 24
+#define AES256_KEYBYTES 32
+#define AESCTR_NONCEBYTES 12
+#define AES_BLOCKBYTES 16
+
+// We've put these states on the heap to make sure ctx_release is used.
+#define PQC_AES128_STATESIZE 88
+typedef struct {
+    uint64_t *sk_exp;
+} aes128ctx;
+
+#define PQC_AES192_STATESIZE 104
+typedef struct {
+    uint64_t  *sk_exp;
+} aes192ctx;
+
+#define PQC_AES256_STATESIZE 120
+typedef struct {
+    uint64_t *sk_exp;
+} aes256ctx;
+
+/** Initializes the context **/
+void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key);
+
+void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key);
+
+void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes128ctx *ctx);
+
+void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes128ctx *ctx);
+
+/** Frees the context **/
+void aes128_ctx_release(aes128ctx *r);
+
+/** Initializes the context **/
+void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key);
+
+void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key);
+
+void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes192ctx *ctx);
+
+void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes192ctx *ctx);
+
+void aes192_ctx_release(aes192ctx *r);
+
+/** Initializes the context **/
+void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key);
+
+void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key);
+
+void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes256ctx *ctx);
+
+void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes256ctx *ctx);
+
+/** Frees the context **/
+void aes256_ctx_release(aes256ctx *r);
+
+#endif

--- a/test/common/nistkatrng.c
+++ b/test/common/nistkatrng.c
@@ -1,0 +1,117 @@
+//
+//  rng.c
+//
+//  Created by Bassham, Lawrence E (Fed) on 8/29/17.
+//  Copyright © 2017 Bassham, Lawrence E (Fed). All rights reserved.
+/*
+NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+
+NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+
+You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+//  Modified for liboqs by Douglas Stebila
+//  Taken from PQClean and modified for libjade by Pravek Sharma
+//
+
+#include <assert.h>
+#include <string.h>
+
+#include "aes.h"
+#include "nistkatrng.h"
+
+typedef struct {
+    uint8_t Key[32];
+    uint8_t V[16];
+    int reseed_counter;
+} AES256_CTR_DRBG_struct;
+
+static AES256_CTR_DRBG_struct DRBG_ctx;
+static void AES256_CTR_DRBG_Update(const uint8_t *provided_data, uint8_t *Key, uint8_t *V);
+
+// Use whatever AES implementation you have. This uses AES from openSSL library
+//    key - 256-bit AES key
+//    ctr - a 128-bit plaintext value
+//    buffer - a 128-bit ciphertext value
+static void AES256_ECB(uint8_t *key, uint8_t *ctr, uint8_t *buffer) {
+    aes256ctx ctx;
+    aes256_ecb_keyexp(&ctx, key);
+    aes256_ecb(buffer, ctr, 1, &ctx);
+    aes256_ctx_release(&ctx);
+}
+
+void nist_kat_init(uint8_t *entropy_input, const uint8_t *personalization_string, int security_strength) {
+    uint8_t seed_material[48];
+
+    assert(security_strength == 256);
+    memcpy(seed_material, entropy_input, 48);
+    if (personalization_string) {
+        for (int i = 0; i < 48; i++) {
+            seed_material[i] ^= personalization_string[i];
+        }
+    }
+    memset(DRBG_ctx.Key, 0x00, 32);
+    memset(DRBG_ctx.V, 0x00, 16);
+    AES256_CTR_DRBG_Update(seed_material, DRBG_ctx.Key, DRBG_ctx.V);
+    DRBG_ctx.reseed_counter = 1;
+}
+
+int nist_kat(uint8_t *buf, size_t n) {
+    uint8_t block[16];
+    int i = 0;
+
+    while (n > 0) {
+        //increment V
+        for (int j = 15; j >= 0; j--) {
+            if (DRBG_ctx.V[j] == 0xff) {
+                DRBG_ctx.V[j] = 0x00;
+            } else {
+                DRBG_ctx.V[j]++;
+                break;
+            }
+        }
+        AES256_ECB(DRBG_ctx.Key, DRBG_ctx.V, block);
+        if (n > 15) {
+            memcpy(buf + i, block, 16);
+            i += 16;
+            n -= 16;
+        } else {
+            memcpy(buf + i, block, n);
+            n = 0;
+        }
+    }
+    AES256_CTR_DRBG_Update(NULL, DRBG_ctx.Key, DRBG_ctx.V);
+    DRBG_ctx.reseed_counter++;
+    return 0;
+}
+
+static void AES256_CTR_DRBG_Update(const uint8_t *provided_data, uint8_t *Key, uint8_t *V) {
+    uint8_t temp[48];
+
+    for (int i = 0; i < 3; i++) {
+        //increment V
+        for (int j = 15; j >= 0; j--) {
+            if (V[j] == 0xff) {
+                V[j] = 0x00;
+            } else {
+                V[j]++;
+                break;
+            }
+        }
+
+        AES256_ECB(Key, V, temp + 16 * i);
+    }
+    if (provided_data != NULL) {
+        for (int i = 0; i < 48; i++) {
+            temp[i] ^= provided_data[i];
+        }
+    }
+    memcpy(Key, temp, 32);
+    memcpy(V, temp + 32, 16);
+}
+
+int __jasmin_syscall_randombytes__(uint8_t* x, uint64_t xlen)
+{
+  return nist_kat(x, xlen);
+//   return x;
+}

--- a/test/common/nistkatrng.h
+++ b/test/common/nistkatrng.h
@@ -1,0 +1,29 @@
+#ifndef NISTKATRNG_H
+#define NISTKATRNG_H
+
+// Taken from PQClean common/randombytes.h and modified for libjade by Pravek Sharma
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#ifdef _WIN32
+/* Load size_t on windows */
+#include <crtdefs.h>
+#else
+#include <unistd.h>
+#endif /* _WIN32 */
+
+void nist_kat_init(uint8_t *entropy_input, const uint8_t *personalization_string, int security_strength);
+
+int nist_kat(uint8_t *output, size_t n);
+
+int __jasmin_syscall_randombytes__(uint8_t* _x, uint64_t xlen) __asm__("__jasmin_syscall_randombytes__");
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NISTKATRNG_H */

--- a/test/crypto_kem/nistkat.c
+++ b/test/crypto_kem/nistkat.c
@@ -1,3 +1,8 @@
+// Taken from liboqs tests/kat_kem.c and modified for libjade by Pravek Sharma
+// This KAT test only generates a subset of the NIST KAT files.
+// To extract the subset from a submission file, use the command:
+//     cat PQCkemKAT_whatever.rsp | head -n 8 | tail -n 6
+
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -7,42 +12,20 @@
 #include "api.h"
 #include "namespace.h"
 #include "jade_kem.h"
-#include "randombytes.h"
+#include "nistkatrng.h"
 #include "config.h"
 
-/*
-int jade_kem_keypair(
-  uint8_t *public_key,
-  uint8_t *secret_key
-);
-
-int jade_kem_enc(
-  uint8_t *ciphertext,
-  uint8_t *shared_secret,
-  const uint8_t *public_key
-);
-
-int jade_kem_dec(
-  uint8_t *shared_secret,
-  const uint8_t *ciphertext,
-  const uint8_t *secret_key
-);
-
-//
-
-int jade_kem_keypair_derand(
-  uint8_t *public_key,
-  uint8_t *secret_key,
-  const uint8_t *coins
-);
-
-int jade_kem_enc_derand(
-  uint8_t *ciphertext,
-  uint8_t *shared_secret,
-  const uint8_t *public_key,
-  const uint8_t *coins
-);
-*/
+static void fprintBstr(FILE *fp, const char *S, const uint8_t *A, size_t L) {
+	size_t i;
+	fprintf(fp, "%s", S);
+	for (i = 0; i < L; i++) {
+		fprintf(fp, "%02X", A[i]);
+	}
+	if (L == 0) {
+		fprintf(fp, "00");
+	}
+	fprintf(fp, "\n");
+}
 
 int main(void)
 {
@@ -50,25 +33,50 @@ int main(void)
   uint8_t public_key[JADE_KEM_PUBLICKEYBYTES];
   uint8_t secret_key[JADE_KEM_SECRETKEYBYTES];
 
-  uint8_t shared_secret[JADE_KEM_BYTES];
+  uint8_t shared_secret_e[JADE_KEM_BYTES];
+  uint8_t shared_secret_d[JADE_KEM_BYTES];
   uint8_t ciphertext[JADE_KEM_CIPHERTEXTBYTES];
 
   uint8_t keypair_coins[JADE_KEM_KEYPAIRCOINBYTES];
   uint8_t enc_coins[JADE_KEM_ENCCOINBYTES];
 
-  __jasmin_syscall_randombytes__(keypair_coins, JADE_KEM_KEYPAIRCOINBYTES);
+	uint8_t entropy_input[48];
+	uint8_t seed[48];
+
+	FILE *fh = NULL;
+
+  for (uint8_t i = 0; i < 48; i++) {
+		entropy_input[i] = i;
+	}
+
+  nist_kat_init(entropy_input, NULL, 256);
+
+	fh = stdout;
+
+  fprintf(fh, "count = 0\n");
+  nist_kat(seed, 48);
+	fprintBstr(fh, "seed = ", seed, 48);
+
+  nist_kat_init(seed, NULL, 256);
+
+  nist_kat(keypair_coins, JADE_KEM_KEYPAIRCOINBYTES/2);
+  nist_kat((uint8_t *)(keypair_coins + (JADE_KEM_KEYPAIRCOINBYTES/2)), JADE_KEM_KEYPAIRCOINBYTES/2);
   r = jade_kem_keypair_derand(public_key, secret_key, keypair_coins);
     assert(r == 0);
+	fprintBstr(fh, "pk = ", public_key, JADE_KEM_PUBLICKEYBYTES);
+	fprintBstr(fh, "sk = ", secret_key, JADE_KEM_SECRETKEYBYTES);
 
-  __jasmin_syscall_randombytes__(enc_coins, JADE_KEM_ENCCOINBYTES);
-  r = jade_kem_enc_derand(ciphertext, shared_secret, public_key, enc_coins);
+  nist_kat(enc_coins, JADE_KEM_ENCCOINBYTES);
+  r = jade_kem_enc_derand(ciphertext, shared_secret_e, public_key, enc_coins);
+    assert(r == 0);
+	fprintBstr(fh, "ct = ", ciphertext, JADE_KEM_CIPHERTEXTBYTES);
+	fprintBstr(fh, "ss = ", shared_secret_e, JADE_KEM_BYTES);
+
+  r = jade_kem_dec(shared_secret_d, ciphertext, secret_key);
     assert(r == 0);
 
-  r = jade_kem_dec(shared_secret, ciphertext, secret_key);
+	r = memcmp(shared_secret_e, shared_secret_d, JADE_KEM_BYTES);
     assert(r == 0);
-
-  // TODO: some hash, to be replaced by the actual checksum
-  printf("5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03");
 
   return 0;
 }

--- a/test/scripts/checksumsok
+++ b/test/scripts/checksumsok
@@ -14,7 +14,12 @@ check_checksums()
   then
     find $baset -name $checksumtype.out | \
     while read checksum_f; do
-      checksum_o=$(cat $checksum_f);
+      if [ "$checksumtype" = "nistkat" ]
+      then
+        checksum_o=$(cat $checksum_f | sed 's/\r\n/\n/g' | sha256sum -b | cut -d' ' -f1)
+      else
+        checksum_o=$(cat $checksum_f);
+      fi
       #echo "$meta / $checksum_o / $checksum_expected";
 
       error=$(dirname $checksum_f)/.ci/$checksumtype.$suffix.error


### PR DESCRIPTION
Adds NIST KAT testing for Kyber from liboqs. Current tests only check 1 of 100 KATs included in `PQCkemKAT_*.rsp` from the Kyber NIST submission.

Modified `test/scripts/checksumok` uses `cut` and `sha256sum` from `gnucoreutils`. 

Some licensing information regarding new files:
- Includes files `common/aes.*` (code provided by BearSSL) and `common/nistkatrng.*` (code provided by NIST) from PQClean.
- `test/crypto_kem/nistkat.c` borrows code from liboqs under the MIT license.

Comments document the above licensing information in new files; please edit/remove them as appropriate. 