### PR TITLE
feat(nix): Add nix derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ci
 *.tar.gz
 libjade-*
+result

--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   ];
 
   buildPhase = ''
-    make FAIL_ON_ERROR=1 -C ../src/ -j$(nproc)
+    make FAIL_ON_ERROR=1 -j$(nproc)
   '';
 
   installPhase = ''

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,33 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+let
+  jasmin-src = fetchFromGitHub {
+    owner = "jasmin-lang";
+    repo = "jasmin";
+    rev = "2264ad9de588706c6042abbda1e52188218e4110";
+    hash = "sha256-tVjYDrb+46jUACJldAPIZt4+H8fC2VJLo+pOD8aeh1U=";
+  };
+
+  jasminc = pkgs.callPackage "${jasmin-src}/default.nix" { inherit pkgs; };
+in
+stdenv.mkDerivation {
+  name = "libjade";
+  src = nix-gitignore.gitignoreSource [ ] ./src;
+
+  nativeBuildInputs = [
+    jasminc
+    gcc
+    gnumake
+  ];
+
+  buildPhase = ''
+    make FAIL_ON_ERROR=1 -C ../src/ -j$(nproc)
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mkdir -p $out/include
+    cp libjade.a $out/lib/
+    cp libjade.h $out/include/
+  '';
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,6 +28,8 @@ ASM     := $(shell find $(SRC) -name '*.s')
 API     := $(addsuffix include/api.h, $(dir $(ASM)))
 OBJ     := $(ASM:%.s=%.o)
 
+FAIL_ON_ERROR ?= 0
+
 # --------------------------------------------------------------------
 ifeq ($(CI),1)
 .PHONY: backward_compatibility
@@ -55,7 +57,7 @@ __libjade: $(OBJ)
 	echo "" | cat - $(API) > libjade.h
 
 $(JAZZ):
-	$(MAKE) -C $@ || true
+	$(MAKE) -C $@ || !(($(FAIL_ON_ERROR)))
 
 # --------------------------------------------------------------------
 


### PR DESCRIPTION
This pull requests adds a nix derivation to the repository that builds libjade with a current version of the jasmin compiler. This allows libjade to be used in other projects using the nix package manager. For example like this:

```
{ pkgs ? import <nixpkgs> { } }:
with pkgs;
let
  libjade-src = fetchFromGitHub {
    owner = "Rixxc";
    repo = "libjade";
    rev = "c4a791e72865e59ce0cd7433edfd01a9ca47b8b3";
    hash = "sha256-ytOM/OvgbxNFLSeWDW0trNaM+iX/8FQdri4q49dix2o=";
  };

  libjade = callPackage "${libjade-src}/default.nix" { };
in
mkShell {
  nativeBuildInputs = [ libjade ];
}
```