### PR TITLE
fix(submodules): use https link instead of ssh link for crypto-spec s…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/tyhicks/ssbd-tools.git
 [submodule "submodules/crypto-specs"]
 	path = submodules/crypto-specs
-	url = git@github.com:formosa-crypto/crypto-specs.git
+	url = https://github.com/formosa-crypto/crypto-specs.git


### PR DESCRIPTION
This pull request changes the ssh link to an https one to prevent issues during recursive clone in nix environments or when the ssh key is not availiable (e.g. due to it being on a hardware token).