### PR TITLE
Refactor ci with private nix action

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Setup nix
+description: Setup nix
+
+inputs:
+  script:
+    description: The script to be run in the nix shell
+    required: false
+  devShell:
+    description: The name of the devShell
+    required: true
+    default: 'default'
+
+runs:
+  using: composite
+  steps:
+    - uses: DeterminateSystems/nix-installer-action@v12
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - name: Prepare nix dev shell
+      shell: nix develop .#${{ inputs.devShell }} -c bash -e {0}
+      run: |
+    - name: Dependency check
+      shell: nix develop .#${{ inputs.devShell }} -c bash -e {0}
+      if: inputs.script != ''
+      env:
+        INPUT_SCRIPT: ${{ inputs.script }}
+      run: eval "$INPUT_SCRIPT"

--- a/.github/workflows/amd64-linux-main-proof.yml
+++ b/.github/workflows/amd64-linux-main-proof.yml
@@ -7,6 +7,10 @@ on:
       - main
   pull_request:
 
+defaults:
+  run:
+    shell: nix develop -c bash -e {0}
+
 jobs:
 
 
@@ -17,18 +21,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - name: Setup nix
+        uses: ./.github/actions/setup-nix
 
       - name: extract and check
-        uses: workflow/nix-shell-action@v3.3.0
-        with:
-          flakes: .
-          flakes-from-devshell: true
-          script: |
-            # extract and check
-            make -j$JOBS -C proof/ CI=1 default
-            # dist
-            ./scripts/ci/releaser/jdist-proof
+        run: |
+          # extract and check
+          make -j$JOBS -C proof/ CI=1 default
+          # dist
+          ./scripts/ci/releaser/jdist-proof
 
       - name: print logs
         run: make         -C proof/ CI=1 reporter

--- a/.github/workflows/amd64-linux-main.yml
+++ b/.github/workflows/amd64-linux-main.yml
@@ -7,6 +7,10 @@ on:
       - main
   pull_request:
 
+defaults:
+  run:
+    shell: nix develop -c bash -e {0}
+
 jobs:
 
 
@@ -17,15 +21,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
-
+      - name: Setup nix
+        uses: ./.github/actions/setup-nix
       - name: compile
-        uses: workflow/nix-shell-action@v3.3.0
-        with:
-          flakes: .
-          flakes-from-devshell: true
-          script: make -j$JOBS -C src/ CI=1 default
-
+        run: make -j$JOBS -C src/ CI=1 default
       - name: print logs
         run: make -C src/ CI=1 reporter
       - name: return error if there are any errors
@@ -47,15 +46,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - name: Setup nix
+        uses: ./.github/actions/setup-nix
 
       - name: compile and run
-        uses: workflow/nix-shell-action@v3.3.0
-        with:
-          flakes: .
-          flakes-from-devshell: true
-          script: make -j$JOBS -C test/ CI=1 default
-
+        run: make -j$JOBS -C test/ CI=1 default
       - name: print logs
         run: make -C test/ CI=1 reporter
       - name: return error if there are any errors
@@ -77,14 +72,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - name: Setup nix
+        uses: ./.github/actions/setup-nix
 
       - name: compile
-        uses: workflow/nix-shell-action@v3.3.0
-        with:
-          flakes: .
-          flakes-from-devshell: true
-          script: make -j$JOBS -C src/   CI=1 default
+        run: make -j$JOBS -C src/   CI=1 default
 
       - name: run
         run: make -j$JOBS -C bench/ CI=1 DEFINE='-DTIMINGS=10' run
@@ -111,14 +103,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - name: Setup nix
+        uses: ./.github/actions/setup-nix
 
       - name: compile
-        uses: workflow/nix-shell-action@v3.3.0
-        with:
-          flakes: .
-          flakes-from-devshell: true
-          script: make -j$JOBS -C src/   CI=1 default
+        run: make -j$JOBS -C src/   CI=1 default
 
       - name: run
         run: make -j$JOBS -C bench/ CI=1 run DEFINE='-DTIMINGS=10 -DRUNS=2 -DST_ON' RANDINC='../test/common/' RANDLIB='../test/common/notrandombytes.c';
@@ -145,18 +134,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - name: Setup nix
+        uses: ./.github/actions/setup-nix
 
       - name: extract and check
-        uses: workflow/nix-shell-action@v3.3.0
-        with:
-          flakes: .
-          flakes-from-devshell: true
-          script: |
-            # extract and check
-            make -j$JOBS -C proof/ CI=1 check-extracted
-            # dist
-            ./scripts/ci/releaser/jdist-proof
+        run: |
+          # extract and check
+          make -j$JOBS -C proof/ CI=1 check-extracted
+          # dist
+          ./scripts/ci/releaser/jdist-proof
 
       - name: print logs
         run: make -C proof/ CI=1 reporter
@@ -187,20 +173,17 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - name: Setup nix
+        uses: ./.github/actions/setup-nix
 
       - name: dist amd64
-        uses: workflow/nix-shell-action@v3.3.0
-        with:
-          flakes: .
-          flakes-from-devshell: true
-          script: |
-            # compile amd64
-            make -j$JOBS -C src/ CI=1 default
-            # dist amd64
-            ./scripts/ci/releaser/jdist-src-v1 amd64
-            # check dist amd64
-            ./scripts/ci/releaser/jdist-src-test-v1 amd64
+        run: |
+          # compile amd64
+          make -j$JOBS -C src/ CI=1 default
+          # dist amd64
+          ./scripts/ci/releaser/jdist-src-v1 amd64
+          # check dist amd64
+          ./scripts/ci/releaser/jdist-src-test-v1 amd64
 
       - name: libjade-dist-src-amd64.tar.gz - contains assembly, Jasmin, and how-to-use code
         if: always()


### PR DESCRIPTION
This PR mainly tried to remove the dependency of nix-shell-action and make use of the `shell` feature provided by github action
- **ci: add nix setup composite action**
- **ci: refactor with the private nix action**
