### PR TITLE
Use = instead of : in jasminc -I

### DIFF
--- a/build-common/Makefile.common
+++ b/build-common/Makefile.common
@@ -84,7 +84,7 @@ JASMIN ?= jasminc
 
 JEXT ?= jazz
 override JFLAGS += -stack-zero loopSCT -noinsertarraycopy
-JINCLUDE ?= -I formosa25519:$(SRC)
+JINCLUDE ?= -I formosa25519=$(SRC)
 
 JASMIN_COMPILE = ($(JASMIN) $(JFLAGS) $(JINCLUDE) -o $@ $<) $(CI_CMD)
 

--- a/oldsrc-should-delete/Makefile.common
+++ b/oldsrc-should-delete/Makefile.common
@@ -34,7 +34,7 @@ endif
 # --------------------------------------------------------------------
 JEXT    ?= jazz
 override JFLAGS += -noinsertarraycopy $(addprefix -slice ,$(FUNCTIONS))
-JINCLUDE = -I Jade:$(SRC)
+JINCLUDE = -I Jade=$(SRC)
 
 JASMIN  ?= jasminc
 JASMINC := $(JASMIN) $(JFLAGS) $(JINCLUDE)


### PR DESCRIPTION
The use of equal as a separator has been introduced in [2025.02.0](https://github.com/jasmin-lang/jasmin/blob/v2025.02.0/CHANGELOG.md#other-changes).