### PR TITLE
Minor cleaning

### DIFF
--- a/oldsrc-should-delete/common/keccak/common/fips202_DIRTY.jinc
+++ b/oldsrc-should-delete/common/keccak/common/fips202_DIRTY.jinc
@@ -27,7 +27,7 @@ fn _sha3_256(reg ptr u8[32] out, reg u64 in inlen) -> reg ptr u8[32]
   for i=0 to 4
   {
     l = a_jagged_p[i];
-    t = s_state[(int) l];
+    t = s_state[l];
     out[u64 i] = t;
   }
 
@@ -53,18 +53,18 @@ fn _sha3_256_32(reg ptr u8[32] out, reg ptr u8[KYBER_SYMBYTES] in) -> reg ptr u8
   {
     t = in[u64 i];
     l = a_jagged_p[i];
-    s_state[(int) l] = t;
+    s_state[l] = t;
   }
 
   l = a_jagged_p[KYBER_SYMBYTES/8];
   l <<= 3;
-  s_state[u8 (int)l] = 0x06;
+  s_state[u8 l] = 0x06;
 
   l = a_jagged_p[(SHA3_256_RATE-1)/8];
   l <<= 3;
   t = SHA3_256_RATE - 1; t &= 0x7;
   l += t;
-  s_state[u8 (int)l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   for i=1 to 7 { state[i] = s_state[u256 i]; }
   
@@ -75,7 +75,7 @@ fn _sha3_256_32(reg ptr u8[32] out, reg ptr u8[KYBER_SYMBYTES] in) -> reg ptr u8
   for i=0 to 4
   {
     l = a_jagged_p[i];
-    t = s_state[(int)l];
+    t = s_state[l];
     out[u64 i] = t;
   }
 
@@ -101,28 +101,28 @@ fn _sha3_256_134(reg ptr u8[32] out, reg ptr u8[134] in) -> reg ptr u8[32]
   {
     t = in[u64 i];
     l = a_jagged_p[i];
-    s_state[(int) l] = t;
+    s_state[l] = t;
   }
 
   c = in[u8 128];
-  l = a_jagged_p[(int) 16];
+  l = a_jagged_p[16];
   l <<= 3;
-  s_state[u8 (int)l] = c;
+  s_state[u8 l] = c;
 
   for i = 129 to 134{
     c = in[i];
     l += 1;
-    s_state[u8 (int)l] = c;
+    s_state[u8 l] = c;
   }
 
   l += 1;
-  s_state[u8 (int)l] = 0x06;
+  s_state[u8 l] = 0x06;
 
   l = a_jagged_p[(SHA3_256_RATE-1)/8];
   l <<= 3;
   t = SHA3_256_RATE - 1; t &= 0x7;
   l += t;
-  s_state[u8 (int)l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   for i=1 to 7 { state[i] = s_state[u256 i]; }
   
@@ -133,7 +133,7 @@ fn _sha3_256_134(reg ptr u8[32] out, reg ptr u8[134] in) -> reg ptr u8[32]
   for i=0 to 4
   {
     l = a_jagged_p[i];
-    t = s_state[(int)l];
+    t = s_state[l];
     out[u64 i] = t;
   }
 
@@ -158,19 +158,19 @@ fn _shake256_64(reg u64 out outlen, reg const ptr u8[64] in)
   {
     l = a_jagged_p[i];
     t = in[u64 i];
-    s_state[(int)l] = t;
+    s_state[l] = t;
   }
 
   l = a_jagged_p[8];
   l <<= 3;
 
-  s_state[u8 (int)l] = 0x1f;
+  s_state[u8 l] = 0x1f;
 
   l = a_jagged_p[(SHAKE256_RATE-1)/8];
   l <<= 3;
   t = SHAKE256_RATE - 1; t &= 0x7;
   l += t;
-  s_state[u8 (int)l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   for i=1 to 7
   { state[i] = s_state[u256 i]; }
@@ -199,22 +199,22 @@ fn _shake256_128_33(reg ptr u8[128] out, reg const ptr u8[33] in) -> reg ptr u8[
   {
     t = in[u64 i];
     l = a_jagged_p[i];
-    s_state[(int)l] = t;
+    s_state[l] = t;
   }
 
   c = in[u8 32];
   l = a_jagged_p[4];
   l <<= 3;
-  s_state[u8 (int)l] = c;
+  s_state[u8 l] = c;
   
   l += 1;
-  s_state[u8 (int)l] = 0x1f;
+  s_state[u8 l] = 0x1f;
 
   l = a_jagged_p[(SHAKE256_RATE-1)/8];
   l <<= 3;
   t = SHAKE256_RATE - 1; t &= 0x7;
   l += t;
-  s_state[u8 (int)l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   for i=1 to 7
   { state[i] = s_state[u256 i]; }
@@ -227,7 +227,7 @@ fn _shake256_128_33(reg ptr u8[128] out, reg const ptr u8[33] in) -> reg ptr u8[
   for i = 0 to 16
   {
     l = a_jagged_p[i];
-    t = s_state[(int)l];
+    t = s_state[l];
     out[u64 i] = t;
   }
 
@@ -252,18 +252,18 @@ fn _sha3_512_64(reg ptr u8[64] out, reg const ptr u8[64] in) -> reg ptr u8[64]
   {
     t = in[u64 i];
     l = a_jagged_p[i];
-    s_state[(int)l] = t;
+    s_state[l] = t;
   }
 
   l = a_jagged_p[8];
   l <<= 3;
-  s_state[u8 (int)l] = 0x06;
+  s_state[u8 l] = 0x06;
 
   l = a_jagged_p[(SHA3_512_RATE-1)/8];
   l <<= 3;
   t = SHA3_512_RATE - 1; t &= 0x7;
   l += t;
-  s_state[u8 (int)l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   for i=1 to 7
   { state[i] = s_state[u256 i]; }
@@ -276,7 +276,7 @@ fn _sha3_512_64(reg ptr u8[64] out, reg const ptr u8[64] in) -> reg ptr u8[64]
   for i = 0 to 8
   {
     l = a_jagged_p[i];
-    t = s_state[(int) l];
+    t = s_state[l];
     out[u64 i] = t;
   }
 
@@ -301,18 +301,18 @@ fn _sha3_512_32(reg ptr u8[64] out, reg const ptr u8[32] in) -> reg ptr u8[64]
   {
     t = in[u64 i];
     l = a_jagged_p[i];
-    s_state[(int)l] = t;
+    s_state[l] = t;
   }
 
   l = a_jagged_p[4];
   l <<= 3;
-  s_state[u8 (int)l] = 0x06;
+  s_state[u8 l] = 0x06;
 
   l = a_jagged_p[(SHA3_512_RATE-1)/8];
   l <<= 3;
   t = SHA3_512_RATE - 1; t &= 0x7;
   l += t;
-  s_state[u8 (int)l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   for i=1 to 7
   { state[i] = s_state[u256 i]; }
@@ -325,7 +325,7 @@ fn _sha3_512_32(reg ptr u8[64] out, reg const ptr u8[32] in) -> reg ptr u8[64]
   for i = 0 to 8
   {
     l = a_jagged_p[i];
-    t = s_state[(int) l];
+    t = s_state[l];
     out[u64 i] = t;
   }
 
@@ -351,26 +351,26 @@ fn __shake128_absorb34(reg u256[7] state, reg const ptr u8[34] in) -> reg u256[7
   {
     t = in[u64 i];
     l = a_jagged_p[i];
-    s_state[(int)l] = t;
+    s_state[l] = t;
   }
 
   t8 = in[32];
-  l = a_jagged_p[(int) 4];
+  l = a_jagged_p[4];
   l <<= 3;
-  s_state[u8 (int)l] = t8;
+  s_state[u8 l] = t8;
 
   t8 = in[33];
   l += 1;
-  s_state[u8 (int)l] = t8;
+  s_state[u8 l] = t8;
 
   l += 1;
-  s_state[u8 (int)l] = 0x1f;
+  s_state[u8 l] = 0x1f;
 
   l = a_jagged_p[(SHAKE128_RATE-1)/8];
   l <<= 3;
   t = SHAKE128_RATE - 1; t &= 0x7;
   l += t;
-  s_state[u8 (int)l] = 0x80;
+  s_state[u8 l] = 0x80;
 
   for i=1 to 7 { state[i] = s_state[u256 i]; }
   
@@ -395,7 +395,7 @@ fn __shake128_squeezeblock(reg u256[7] state, reg ptr u8[SHAKE128_RATE] out) -> 
   for i = 0 to SHAKE128_RATE/8
   {
     l = a_jagged_p[i];
-    t = s_state[(int) l];
+    t = s_state[l];
     out[u64 i] = t;
   }
 

--- a/oldsrc-should-delete/common/keccak/common/fips202_ref_DIRTY.jinc
+++ b/oldsrc-should-delete/common/keccak/common/fips202_ref_DIRTY.jinc
@@ -103,7 +103,7 @@ fn _sha3_512_32(reg ptr u8[64] out, reg const ptr u8[32] in) -> reg ptr u8[64]
   out = s_out;
 
   for i = 0 to 64 {
-    c = state[u8 (int) i];
+    c = state[u8 i];
     out[i] = c;
   }
   return out;
@@ -141,7 +141,7 @@ fn _shake128_squeezeblock(reg ptr u64[25] state, reg ptr u8[SHAKE128_RATE] out) 
   out = s_out;
 
   for i = 0 to SHAKE128_RATE {
-    c = state[u8 (int) i];
+    c = state[u8 i];
     out[i] = c;
   }
 
@@ -359,7 +359,7 @@ fn _shake256_64(reg u64 out outlen, reg const ptr u8[64] in)
   j = 0;
   while(j < outlen)
   {
-    t64 = state[(int) j];
+    t64 = state[j];
     (u64)[out + 8 * j] = t64;
     j = j + 1;
   }
@@ -369,7 +369,7 @@ fn _shake256_64(reg u64 out outlen, reg const ptr u8[64] in)
 
   while (j < outlen)
   {
-    c = state[u8 (int) j];
+    c = state[u8 j];
     (u8)[out + j] = c;
     j = j + 1;
   }

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccak1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccak1600.jinc
@@ -51,10 +51,10 @@ inline fn __add_full_block_avx2(
 
     t = [in + 8*j];
 
-    l = a_jagged_p[(int) j];
+    l = a_jagged_p[j];
     l = #protect(l, ms);
 
-    s_state[(int) l] = t;
+    s_state[l] = t;
     j += 1;
 
   }
@@ -103,15 +103,15 @@ inline fn __add_final_block_avx2(
     ms = #update_msf(loop_condition, ms);
 
     t = [in + 8*j];
-    l = a_jagged_p[(int) j];
+    l = a_jagged_p[j];
     l = #protect(l, ms);    
 
-    s_state[(int) l] = t;
+    s_state[l] = t;
     j += 1;
   }
   ms = #update_msf(!loop_condition, ms);
 
-  l = a_jagged_p[(int) j];
+  l = a_jagged_p[j];
   l = #protect(l, ms);
 
   l <<= 3;
@@ -121,24 +121,24 @@ inline fn __add_final_block_avx2(
   {
     ms = #update_msf(loop_condition, ms);
     c = (u8)[in + j];
-    s_state[u8 (int) l] = c;
+    s_state[u8 l] = c;
     j += 1;
     l += 1;
   }
   ms = #update_msf(!loop_condition, ms);
 
-  s_state[u8 (int) l] = trail_byte;
+  s_state[u8 l] = trail_byte;
 
   // j  = (rate-1) >> 3;
   j = rate; j -= 1; j >>= 3;
-  l  = a_jagged_p[(int) j];
+  l  = a_jagged_p[j];
   l = #protect(l, ms);
   l <<= 3;
   // l += ((rate-1) & 0x7)
   j = rate; j -= 1; j &= 0x7;
   l += j;
 
-  s_state[u8 (int) l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   t = s_state[0];
   s_state[1] = t;
@@ -176,10 +176,10 @@ inline fn __xtr_full_block_avx2(
   {
     ms = #update_msf(loop_condition, ms);
 
-    l = a_jagged_p[(int) j];
+    l = a_jagged_p[j];
     l = #protect(l, ms);    
 
-    t = s_state[(int) l];
+    t = s_state[l];
     [out + 8*j] = t;
     j += 1;
   }
@@ -216,16 +216,16 @@ inline fn __xtr_bytes_avx2(
   { 
     ms = #update_msf(loop_condition, ms);
 
-    l = a_jagged_p[(int) j];
+    l = a_jagged_p[j];
     l = #protect(l, ms);
 
-    t = s_state[(int) l];
+    t = s_state[l];
     [out + 8*j] = t;
     j += 1;
   }
   ms = #update_msf(!loop_condition, ms);
 
-  l = a_jagged_p[(int)j];
+  l = a_jagged_p[j];
   l = #protect(l, ms);
 
   j <<= 3;
@@ -233,7 +233,7 @@ inline fn __xtr_bytes_avx2(
 
   while ( j < len )
   {
-    c = s_state[u8 (int) l];
+    c = s_state[u8 l];
     (u8)[out + j] = c;
     j += 1;
     l += 1;

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccak1600_nomsf.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccak1600_nomsf.jinc
@@ -46,8 +46,8 @@ inline fn __add_full_block_avx2(
   while ( j < rate8 )
   {
     t = [in + 8*j];
-    l = a_jagged_p[(int) j];
-    s_state[(int) l] = t;
+    l = a_jagged_p[j];
+    s_state[l] = t;
     j += 1;
   }
 
@@ -89,33 +89,33 @@ inline fn __add_final_block_avx2(
   while ( j < inlen8 )
   {
     t = [in + 8*j];
-    l = a_jagged_p[(int) j];
-    s_state[(int) l] = t;
+    l = a_jagged_p[j];
+    s_state[l] = t;
     j += 1;
   }
-  l = a_jagged_p[(int) j];
+  l = a_jagged_p[j];
   l <<= 3;
   j <<= 3;
 
   while ( j < inlen )
   {
     c = (u8)[in + j];
-    s_state[u8 (int) l] = c;
+    s_state[u8 l] = c;
     j += 1;
     l += 1;
   }
 
-  s_state[u8 (int) l] = trail_byte;
+  s_state[u8 l] = trail_byte;
 
   // j  = (rate-1) >> 3;
   j = rate; j -= 1; j >>= 3;
-  l  = a_jagged_p[(int) j];
+  l  = a_jagged_p[j];
   l <<= 3;
   // l += ((rate-1) & 0x7)
   j = rate; j -= 1; j &= 0x7;
   l += j;
 
-  s_state[u8 (int) l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   t = s_state[0];
   s_state[1] = t;
@@ -149,8 +149,8 @@ inline fn __xtr_full_block_avx2(
   j = 0;
   while ( j < len8 )
   {
-    l = a_jagged_p[(int) j];
-    t = s_state[(int) l];
+    l = a_jagged_p[j];
+    t = s_state[l];
     [out + 8*j] = t;
     j += 1;
   }
@@ -181,18 +181,18 @@ inline fn __xtr_bytes_avx2(
   len8 >>= 3;
   j = 0;
   while ( j < len8 )
-  { l = a_jagged_p[(int) j];
-    t = s_state[(int) l];
+  { l = a_jagged_p[j];
+    t = s_state[l];
     [out + 8*j] = t;
     j += 1;
   }
-  l = a_jagged_p[(int)j];
+  l = a_jagged_p[j];
   j <<= 3;
   l <<= 3;
 
   while ( j < len )
   {
-    c = s_state[u8 (int) l];
+    c = s_state[u8 l];
     (u8)[out + j] = c;
     j += 1;
     l += 1;

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccakf1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccakf1600.jinc
@@ -190,7 +190,7 @@ inline fn __keccakf1600_avx2(reg u256[7] state, #msf reg u64 ms) -> reg u256[7],
 	  state[4] = state[4] ^ t[4];
 
 	  //######################################## Iota
-	  state[0] = state[0] ^ iotas_p.[(int) iotas_o];
+	  state[0] = state[0] ^ iotas_p.[iotas_o];
     iotas_o += 32;
 
     _,_,_,zf,r = #DEC_64(r);

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccakf1600_4x.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccakf1600_4x.jinc
@@ -188,7 +188,7 @@ inline fn __keccakf1600_4x_avx2(reg ptr u256[25] a) -> reg ptr u256[25]
   c = 0;
   while
   {
-    rc = RC.[(int) c];
+    rc = RC.[c];
     e = __round_4x_avx2(e, a, rc, r8, r56);
 
     rc = RC.[(int) c + 32];

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccakf1600_nomsf.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/avx2/keccakf1600_nomsf.jinc
@@ -190,7 +190,7 @@ inline fn __keccakf1600_avx2(reg u256[7] state) -> reg u256[7]
 	  state[4] = state[4] ^ t[4];
 
 	  //######################################## Iota
-	  state[0] = state[0] ^ iotas_p.[(int) iotas_o];
+	  state[0] = state[0] ^ iotas_p.[iotas_o];
     iotas_o += 32;
 
     _,_,_,zf,r = #DEC_64(r);

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/bmi1/keccak1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/bmi1/keccak1600.jinc
@@ -31,7 +31,7 @@ inline fn __add_full_block_bmi1(
   while( i < rate64)
   {
     t = [in + 8*i];
-    state[(int)i] ^= t;
+    state[i] ^= t;
     i+=1;
   }
 
@@ -59,7 +59,7 @@ inline fn __add_final_block_bmi1(
   while ( i < inlen8 )
   {
     t = [in + 8*i];
-    state[(int)i] ^= t;
+    state[i] ^= t;
     i += 1;
   }
 
@@ -67,15 +67,15 @@ inline fn __add_final_block_bmi1(
   while ( i < inlen )
   {
     c = (u8)[in + i];
-    state[u8 (int)i] ^= c;
+    state[u8 i] ^= c;
     i += 1;
   }
 
-  state[u8 (int)i] ^= trail_byte;
+  state[u8 i] ^= trail_byte;
 
   i = rate;
   i -= 1;
-  state[u8 (int)i] ^= 0x80;
+  state[u8 i] ^= 0x80;
 
   return state;
 }
@@ -129,7 +129,7 @@ inline fn __xtr_full_block_bmi1(
   i = 0;
   while ( i < rate64 )
   {
-    t = state[(int)i];
+    t = state[i];
     [out + 8*i] = t;
     i += 1;
   }
@@ -154,7 +154,7 @@ inline fn __xtr_bytes_bmi1(
   i = 0;
   while ( i < outlen8 )
   {
-    t = state[(int)i];
+    t = state[i];
     [out + 8*i] = t;
     i += 1;
   }
@@ -162,7 +162,7 @@ inline fn __xtr_bytes_bmi1(
 
   while ( i < outlen )
   {
-    c = state[u8 (int)i];
+    c = state[u8 i];
     (u8)[out + i] = c;
     i += 1;
   }

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/bmi1/keccakf1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/bmi1/keccakf1600.jinc
@@ -142,7 +142,7 @@ inline fn __keccakf1600_bmi1(reg ptr u64[25] a) -> reg ptr u64[25]
   while (c < KECCAK_ROUNDS - 1)
   {
     RC = s_RC;
-    rc = RC[(int) c];
+    rc = RC[c];
     e = __round_bmi1(e, a, rc);
 
     RC = s_RC;

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref/keccak1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref/keccak1600.jinc
@@ -30,7 +30,7 @@ inline fn __add_full_block_ref(
   while( i < rate64)
   {
     t = [in + 8*i];
-    state[(int)i] ^= t;
+    state[i] ^= t;
     i+=1;
   }
 
@@ -58,7 +58,7 @@ inline fn __add_final_block_ref(
   while ( i < inlen8 )
   {
     t = [in + 8*i];
-    state[(int)i] ^= t;
+    state[i] ^= t;
     i += 1;
   }
 
@@ -66,15 +66,15 @@ inline fn __add_final_block_ref(
   while ( i < inlen )
   {
     c = (u8)[in + i];
-    state[u8 (int)i] ^= c;
+    state[u8 i] ^= c;
     i += 1;
   }
 
-  state[u8 (int)i] ^= trail_byte;
+  state[u8 i] ^= trail_byte;
 
   i = rate;
   i -= 1;
-  state[u8 (int)i] ^= 0x80;
+  state[u8 i] ^= 0x80;
 
   return state;
 }
@@ -126,7 +126,7 @@ inline fn __xtr_full_block_ref(
   i = 0;
   while ( i < rate64 )
   {
-    t = state[(int)i];
+    t = state[i];
     [out + 8*i] = t;
     i += 1;
   }
@@ -151,7 +151,7 @@ inline fn __xtr_bytes_ref(
   i = 0;
   while ( i < outlen8 )
   {
-    t = state[(int)i];
+    t = state[i];
     [out + 8*i] = t;
     i += 1;
   }
@@ -159,7 +159,7 @@ inline fn __xtr_bytes_ref(
 
   while ( i < outlen )
   {
-    c = state[u8 (int)i];
+    c = state[u8 i];
     (u8)[out + i] = c;
     i += 1;
   }

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref/keccakf1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref/keccakf1600.jinc
@@ -136,7 +136,7 @@ inline fn __keccakf1600_ref(stack u64[25] a) -> stack u64[25]
   c = 0;
   while (c < KECCAK_ROUNDS - 1)
   {
-    rc = RC[(int) c];
+    rc = RC[c];
     e = __round_ref(a, rc);
 
     rc = RC[(int) c + 1];

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref/keccakf1600_v0.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref/keccakf1600_v0.jinc
@@ -176,7 +176,7 @@ inline fn __get_iota_ref(reg ptr u64[25] sp, reg u64 round) -> stack u64
   reg u64 v;
 
   p = sp;
-  v = p[(int)round];
+  v = p[round];
   sv = v;
 
   return sv;
@@ -193,11 +193,11 @@ inline fn __keccakf1600_ref(stack u64[25] a) -> stack u64[25]
 
   while(round < 24)
   {
-    iota = iotas_p[(int) round];
+    iota = iotas_p[round];
     a, r = __round2x_ref(a, r, iota);
     round += 1;
 
-    iota = iotas_p[(int) round];
+    iota = iotas_p[round];
     r, a = __round2x_ref(r, a, iota);
     round += 1;
   }

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref1/keccak1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref1/keccak1600.jinc
@@ -30,7 +30,7 @@ inline fn __add_full_block_ref1(
   while( i < rate64)
   {
     t = [in + 8*i];
-    state[(int)i] ^= t;
+    state[i] ^= t;
     i+=1;
   }
 
@@ -58,7 +58,7 @@ inline fn __add_final_block_ref1(
   while ( i < inlen8 )
   {
     t = [in + 8*i];
-    state[(int)i] ^= t;
+    state[i] ^= t;
     i += 1;
   }
 
@@ -66,15 +66,15 @@ inline fn __add_final_block_ref1(
   while ( i < inlen )
   {
     c = (u8)[in + i];
-    state[u8 (int)i] ^= c;
+    state[u8 i] ^= c;
     i += 1;
   }
 
-  state[u8 (int)i] ^= trail_byte;
+  state[u8 i] ^= trail_byte;
 
   i = rate;
   i -= 1;
-  state[u8 (int)i] ^= 0x80;
+  state[u8 i] ^= 0x80;
 
   return state;
 }
@@ -128,7 +128,7 @@ inline fn __xtr_full_block_ref1(
   i = 0;
   while ( i < rate64 )
   {
-    t = state[(int)i];
+    t = state[i];
     [out + 8*i] = t;
     i += 1;
   }
@@ -153,7 +153,7 @@ inline fn __xtr_bytes_ref1(
   i = 0;
   while ( i < outlen8 )
   {
-    t = state[(int)i];
+    t = state[i];
     [out + 8*i] = t;
     i += 1;
   }
@@ -161,7 +161,7 @@ inline fn __xtr_bytes_ref1(
 
   while ( i < outlen )
   {
-    c = state[u8 (int)i];
+    c = state[u8 i];
     (u8)[out + i] = c;
     i += 1;
   }

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref1/keccakf1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/ref1/keccakf1600.jinc
@@ -141,7 +141,7 @@ inline fn __keccakf1600_ref1(reg ptr u64[25] a) -> reg ptr u64[25]
   c = 0;
   while (c < KECCAK_ROUNDS - 1)
   {
-    rc = RC[(int) c];
+    rc = RC[c];
     e = __round_ref1(e, a, rc);
 
     rc = RC[(int) c + 1];

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/spec/keccak1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/spec/keccak1600.jinc
@@ -28,7 +28,7 @@ inline fn __add_full_block_spec(
   while (i < r64)
   {
     t = [in + 8 * i];
-    state[(int) i] ^= t;
+    state[i] ^= t;
     i = i + 1;
   }
 
@@ -56,7 +56,7 @@ inline fn __add_final_block_spec(
   while ( i < inlen8)
   {
     t = [in + 8*i];
-    state[(int) i] ^= t;
+    state[i] ^= t;
     i = i + 1;
   }
 
@@ -64,15 +64,15 @@ inline fn __add_final_block_spec(
   while (i < inlen)
   {
     c = (u8)[in + i];
-    state[u8 (int) i] ^= c;
+    state[u8 i] ^= c;
     i = i + 1;
   }
 
-  state[u8 (int) i] ^= trail_byte;
+  state[u8 i] ^= trail_byte;
 
   i = r8;
   i -= 1;
-  state[u8 (int) i] ^= 0x80;
+  state[u8 i] ^= 0x80;
 
   return state;
 }
@@ -92,7 +92,7 @@ inline fn __xtr_full_block_spec(
   i = 0;
   while (i < rate64)
   {
-    t = state[(int) i];
+    t = state[i];
     [out + 8 * i] = t;
     i = i + 1;
   }
@@ -118,7 +118,7 @@ inline fn __xtr_bytes_spec(
   i = 0;
   while (i < outlen8 )
   {
-    t = state[(int) i];
+    t = state[i];
     [out + 8 * i] = t;
     i = i + 1;
   }
@@ -126,7 +126,7 @@ inline fn __xtr_bytes_spec(
 
   while (i < outlen)
   {
-    c = state[u8 (int) i];
+    c = state[u8 i];
     (u8)[out + i] = c;
     i = i + 1;
   }

--- a/oldsrc-should-delete/common/keccak/keccak1600/amd64/spec/keccakf1600.jinc
+++ b/oldsrc-should-delete/common/keccak/keccak1600/amd64/spec/keccakf1600.jinc
@@ -153,7 +153,7 @@ inline fn __keccakf1600_spec(stack u64[25] state) -> stack u64[25]
   round = 0;
   while(round < 24)
   {
-    RC = kRCp[(int) round];
+    RC = kRCp[round];
     state = __keccakP1600_round_spec(state, RC);
     round += 1;
   }

--- a/oldsrc-should-delete/crypto_hash/sha256/amd64/ref/sha256.jinc
+++ b/oldsrc-should-delete/crypto_hash/sha256/amd64/ref/sha256.jinc
@@ -223,8 +223,8 @@ fn _blocks_0_ref(reg ptr u32[8] _H, reg u64 in inlen) -> reg ptr u32[8], reg u64
       T1 += r;
       r   = __CH_ref(e,f,g);
       T1 += r;
-      T1 += Kp[(int)tr];
-      T1 += W[(int)tr];
+      T1 += Kp[tr];
+      T1 += W[tr];
 
       //T2 = BSIG0(a) + MAJ(a,b,c)
       T2  = __BSIG0_ref(a);
@@ -311,8 +311,8 @@ fn _blocks_1_ref(reg ptr u32[8] _H, reg ptr u32[32] sblocks, reg u64 nblocks) ->
       T1 += r;
       r   = __CH_ref(e,f,g);
       T1 += r;
-      T1 += Kp[(int)tr];
-      T1 += W[(int)tr];
+      T1 += Kp[tr];
+      T1 += W[tr];
 
       //T2 = BSIG0(a) + MAJ(a,b,c)
       T2  = __BSIG0_ref(a);
@@ -370,12 +370,12 @@ inline fn __lastblocks_ref(reg u64 in inlen bits) -> stack u32[32], reg u64
   // copy in to sblocks
   while(i < inlen)
   { v = (u8)[in + i];
-    sblocks[u8 (int)i] = v;
+    sblocks[u8 i] = v;
     i += 1;
   }
 
   // set first byte after input to 0x80 
-  sblocks[u8 (int)i] = 0x80;
+  sblocks[u8 i] = 0x80;
 
   // check if one or two blocks are needed
   if(inlen < 56) // 448 / 8 = 56
@@ -384,7 +384,7 @@ inline fn __lastblocks_ref(reg u64 in inlen bits) -> stack u32[32], reg u64
   { j = (128-8); nblocks = 2; i = 127; }
 
   while(i >= j)
-  { sblocks[u8 (int)i] = (8u) bits;
+  { sblocks[u8 i] = (8u) bits;
     bits >>= 8;
     i -= 1;
   }

--- a/oldsrc-should-delete/crypto_hash/sha512/amd64/ref/sha512.jinc
+++ b/oldsrc-should-delete/crypto_hash/sha512/amd64/ref/sha512.jinc
@@ -223,8 +223,8 @@ fn _blocks_0_ref(reg ptr u64[8] _H, reg u64 in inlen) -> reg ptr u64[8], reg u64
       T1 += r;
       r   = __CH_ref(e,f,g);
       T1 += r;
-      T1 += Kp[(int)tr];
-      T1 += W[(int)tr];
+      T1 += Kp[tr];
+      T1 += W[tr];
 
       //T2 = BSIG0(a) + MAJ(a,b,c)
       T2  = __BSIG0_ref(a);
@@ -311,8 +311,8 @@ fn _blocks_1_ref(reg ptr u64[8] _H, reg ptr u64[32] sblocks, reg u64 nblocks) ->
       T1 += r;
       r   = __CH_ref(e,f,g);
       T1 += r;
-      T1 += Kp[(int)tr];
-      T1 += W[(int)tr];
+      T1 += Kp[tr];
+      T1 += W[tr];
 
       //T2 = BSIG0(a) + MAJ(a,b,c)
       T2  = __BSIG0_ref(a);
@@ -370,12 +370,12 @@ inline fn __lastblocks_ref(reg u64 in inlen bits) -> stack u64[32], reg u64
   // copy in to sblocks
   while(i < inlen)
   { v = (u8)[in + i];
-    sblocks[u8 (int)i] = v;
+    sblocks[u8 i] = v;
     i += 1;
   }
 
   // set first byte after input to 0x80 
-  sblocks[u8 (int)i] = 0x80;
+  sblocks[u8 i] = 0x80;
 
   // check if one or two blocks are needed
   if(inlen < 112)
@@ -384,7 +384,7 @@ inline fn __lastblocks_ref(reg u64 in inlen bits) -> stack u64[32], reg u64
   { j = (256-8); nblocks = 2; i = 255; }
 
   while(i >= j)
-  { sblocks[u8 (int)i] = (8u) bits;
+  { sblocks[u8 i] = (8u) bits;
     bits >>= 8;
     i -= 1;
   }

--- a/oldsrc-should-delete/crypto_kem/kyber/common/amd64/avx2/verify.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/common/amd64/avx2/verify.jinc
@@ -57,7 +57,7 @@ fn __cmov(reg ptr u8[KYBER_SYMBYTES] dst, reg u64 src cnd) -> reg ptr u8[KYBER_S
   {
     f = dst.[u256 32*i];
     g = (u256)[src + 32*i];
-    f = #VPBLENDVB_256(f, g, m);
+    f = #BLENDV_32u8(f, g, m);
     dst.[u256 32*i] = f;
   }
 

--- a/oldsrc-should-delete/crypto_kem/kyber/common/amd64/ref/gen_matrix.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/common/amd64/ref/gen_matrix.jinc
@@ -12,9 +12,9 @@ fn __rej_uniform(stack u16[KYBER_N] rp, reg u64 offset, stack u8[SHAKE128_RATE] 
   pos = 0;
 
   while {
-    val1 = (16u)buf[(int)pos];
+    val1 = (16u)buf[pos];
     pos += 1;
-    t   = (16u)buf[(int)pos];
+    t   = (16u)buf[pos];
     val2 = t;
     val2 >>= 4;
     t &= 0x0F;
@@ -22,7 +22,7 @@ fn __rej_uniform(stack u16[KYBER_N] rp, reg u64 offset, stack u8[SHAKE128_RATE] 
     val1 |= t;
     pos += 1;
 
-    t   = (16u)buf[(int)pos];
+    t   = (16u)buf[pos];
     t <<= 4;
     val2 |= t;
     pos += 1;
@@ -30,7 +30,7 @@ fn __rej_uniform(stack u16[KYBER_N] rp, reg u64 offset, stack u8[SHAKE128_RATE] 
     if(val1 < KYBER_Q)
     {
         if(ctr < KYBER_N) {
-            rp[(int)ctr] = val1;
+            rp[ctr] = val1;
             ctr += 1;
         }
     }
@@ -39,7 +39,7 @@ fn __rej_uniform(stack u16[KYBER_N] rp, reg u64 offset, stack u8[SHAKE128_RATE] 
     {
       if(ctr < KYBER_N)
       {
-        rp[(int)ctr] = val2;
+        rp[ctr] = val2;
         ctr += 1;
       }
     }
@@ -96,7 +96,7 @@ fn __gen_matrix(stack u8[KYBER_SYMBYTES] seed, reg u64 transposed) -> stack u16[
       ctr = 0;
       #bounded
       while (ctr < KYBER_N / 4) {
-        poly[u64 (int) ctr] = ctr;
+        poly[u64 ctr] = ctr;
         ctr += 1;
       }
 
@@ -115,8 +115,8 @@ fn __gen_matrix(stack u8[KYBER_SYMBYTES] seed, reg u64 transposed) -> stack u16[
       #bounded
       while (k < KYBER_N)
       {
-        t = poly[(int) k];
-        r[(int) l] = t;
+        t = poly[k];
+        r[l] = t;
         k += 1;
         l += 1;
       }

--- a/oldsrc-should-delete/crypto_kem/kyber/common/amd64/ref/poly.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/common/amd64/ref/poly.jinc
@@ -13,10 +13,10 @@ fn _poly_add2(reg ptr u16[KYBER_N] rp bp) -> reg ptr u16[KYBER_N]
   i = 0;
 
   while (i < KYBER_N) {
-    a = rp[(int)i];
-    b = bp[(int)i];
+    a = rp[i];
+    b = bp[i];
     r = a + b;
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -31,13 +31,13 @@ fn _poly_csubq(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
   i = 0;
   while (i < KYBER_N)
   {
-    t = rp[(int)i];
+    t = rp[i];
     t -= KYBER_Q;
     b = t;
     b >>s= 15;
     b &= KYBER_Q;
     t += b;
-    rp[(int)i] = t;
+    rp[i] = t;
     i += 1;
   }
   return rp;
@@ -67,14 +67,14 @@ fn _poly_basemul(reg ptr u16[KYBER_N] rp, reg const ptr u16[KYBER_N] ap bp) -> r
   while(i < KYBER_N)
   {
     zetasp = jzetas;
-    zeta = zetasp[(int)zetasctr];
+    zeta = zetasp[zetasctr];
     zetasctr += 1;
     
-    a0 = ap[(int)i];
-    b0 = bp[(int)i];
+    a0 = ap[i];
+    b0 = bp[i];
     i += 1;
-    a1 = ap[(int)i];
-    b1 = bp[(int)i];
+    a1 = ap[i];
+    b1 = bp[i];
     i -= 1;
 
     r0 = __fqmul(a1, b1);
@@ -87,20 +87,20 @@ fn _poly_basemul(reg ptr u16[KYBER_N] rp, reg const ptr u16[KYBER_N] ap bp) -> r
     r1 += t;
 
     rp = srp;
-    rp[(int)i]   = r0;
+    rp[i]   = r0;
     i += 1;
-    rp[(int)i] = r1;
+    rp[i] = r1;
     srp = rp;
 
 
     zeta = -zeta;
 
     i += 1;
-    a0 = ap[(int)i];
-    b0 = bp[(int)i];
+    a0 = ap[i];
+    b0 = bp[i];
     i += 1;
-    a1 = ap[(int)i];
-    b1 = bp[(int)i];
+    a1 = ap[i];
+    b1 = bp[i];
     i -= 1;
 
     r0 = __fqmul(a1, b1);
@@ -113,9 +113,9 @@ fn _poly_basemul(reg ptr u16[KYBER_N] rp, reg const ptr u16[KYBER_N] ap bp) -> r
     r1 += t;
 
     rp = srp;
-    rp[(int)i]   = r0;
+    rp[i]   = r0;
     i += 1;
-    rp[(int)i] = r1;
+    rp[i] = r1;
     srp = rp;
     
     i += 1;
@@ -131,9 +131,9 @@ fn __poly_reduce(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
   j = 0;
   while (j < KYBER_N) 
   {
-    t = rp[(int)j];
+    t = rp[j];
     t = __barrett_reduce(t);
-    rp[(int)j] = t;
+    rp[j] = t;
     j += 1;
   }
   return rp;
@@ -151,7 +151,7 @@ fn _poly_compress(reg u64 rp, reg ptr u16[KYBER_N] a) -> reg ptr u16[KYBER_N]
   j = 0;
   while(i < 128)
   {
-    t  = a[(int)j];
+    t  = a[j];
     d0 = (32u)t;
     d0 <<= 4;
     d0 += 1665;
@@ -159,7 +159,7 @@ fn _poly_compress(reg u64 rp, reg ptr u16[KYBER_N] a) -> reg ptr u16[KYBER_N]
     d0 >>= 28;
     d0 &= 0xf;
     j += 1;
-    t  = a[(int)j];
+    t  = a[j];
     d1 = (32u)t;
     d1 <<= 4;
     d1 += 1665;
@@ -187,7 +187,7 @@ fn _i_poly_compress(reg ptr u8[KYBER_POLYCOMPRESSEDBYTES] rp, reg ptr u16[KYBER_
   j = 0;
   while(i < 128)
   {
-    t  = a[(int)j];
+    t  = a[j];
     d0 = (32u)t;
     d0 <<= 4;
     d0 += 1665;
@@ -195,7 +195,7 @@ fn _i_poly_compress(reg ptr u8[KYBER_POLYCOMPRESSEDBYTES] rp, reg ptr u16[KYBER_
     d0 >>= 28;
     d0 &= 0xf;
     j += 1;
-    t  = a[(int)j];
+    t  = a[j];
     d1 = (32u)t;
     d1 <<= 4;
     d1 += 1665;
@@ -204,7 +204,7 @@ fn _i_poly_compress(reg ptr u8[KYBER_POLYCOMPRESSEDBYTES] rp, reg ptr u16[KYBER_
     d1 &= 0xf;
     d1 <<= 4;
     d0 |= d1;
-    rp[(int) i] = d0;
+    rp[i] = d0;
     i += 1;
     j += 1;
   }
@@ -233,9 +233,9 @@ fn _poly_decompress(reg ptr u16[KYBER_N] rp, reg u64 ap) -> reg ptr u16[KYBER_N]
     d1 += 8;
     d0 >>= 4;
     d1 >>= 4;
-    rp[(int)j] = d0;
+    rp[j] = d0;
     j += 1;
-    rp[(int)j] = d1;
+    rp[j] = d1;
     j += 1;
     i += 1;
   }
@@ -282,9 +282,9 @@ fn _poly_frommont(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
   i = 0;
   while (i < KYBER_N)
   {
-    r = rp[(int)i];
+    r = rp[i];
     r = __fqmul(r, dmont);
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp; 
@@ -424,7 +424,7 @@ fn __cbd2(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_ETA2*KYBER_N/4] buf) -> reg 
   i = 0;
   j = 0;
   while (i < KYBER_ETA2*KYBER_N/4) {
-    c = buf[(int)i];
+    c = buf[i];
     a = c;
     a &= 0x55;
 
@@ -439,7 +439,7 @@ fn __cbd2(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_ETA2*KYBER_N/4] buf) -> reg 
     b &= 0x3;
     a -= b;
     t = (16s)a;
-    rp[(int)j] = t;
+    rp[j] = t;
     a = c;
     a >>= 4;
     a &= 0x3;
@@ -448,7 +448,7 @@ fn __cbd2(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_ETA2*KYBER_N/4] buf) -> reg 
     a -= b;
     t = (16s)a;
     j += 1;
-    rp[(int)j] = t;
+    rp[j] = t;
     i += 1;
     j += 1;
   }
@@ -462,7 +462,7 @@ fn __load24(reg ptr u8[KYBER_ETA1*KYBER_N/4] buf, reg u64 i) -> reg u32
 {
   reg u32 r t;
 
-  r = (32u)buf[(int)i];
+  r = (32u)buf[i];
 
   t = (32u)buf[(int)i+1];
   t <<= 8;
@@ -516,7 +516,7 @@ fn __cbd3(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_ETA1*KYBER_N/4] buf) -> reg 
 
       a -= b;
       r = (16s)a;
-      rp[(int)j] = r;
+      rp[j] = r;
 
       t0 >>= 6;
       j += 1;
@@ -638,7 +638,7 @@ fn _poly_invntt(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
     start = 0;
     while (start < 256)
     {
-      zeta = zetasp[(int)zetasctr];
+      zeta = zetasp[zetasctr];
       zetasctr += 1;
 
       j = start;
@@ -646,14 +646,14 @@ fn _poly_invntt(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
       while (j < cmp)
       {
         offset = #LEA(j + len); //offset = j + len;
-        s = rp[(int)offset];
-        t = rp[(int)j];
+        s = rp[offset];
+        t = rp[j];
         m = s; m += t; //m = s + t; //this is not LEA to avoid it for 16-bit (valgrind);
         m = __barrett_reduce(m);
-        rp[(int)j] = m;
+        rp[j] = m;
         t -= s;
         t = __fqmul(t, zeta);
-        rp[(int)offset] = t;
+        rp[offset] = t;
         j += 1;
       }
       start = #LEA(j + len); //start = j + len;
@@ -665,9 +665,9 @@ fn _poly_invntt(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
   j = 0;
   while (j < KYBER_N) 
   {
-    t = rp[(int)j];
+    t = rp[j];
     t = __fqmul(t, zeta);
-    rp[(int)j] = t;
+    rp[j] = t;
     j += 1;
   }
   return rp;
@@ -698,20 +698,20 @@ fn _poly_ntt(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
     while (start < 256)
     {
       zetasctr += 1;
-      zeta = zetasp[(int)zetasctr];
+      zeta = zetasp[zetasctr];
       j = start;
       cmp = #LEA(start + len); // cmp = start + len;
       while (j < cmp)
       {
         offset = #LEA(j + len); // offset = j + len;
-        t = rp[(int)offset];
+        t = rp[offset];
         t = __fqmul(t, zeta);
-        s = rp[(int)j];
+        s = rp[j];
         m = s;
         m -= t;
-        rp[(int)offset] = m;
+        rp[offset] = m;
         t += s;
-        rp[(int)j] = t;
+        rp[j] = t;
         j += 1;
       }
       start = #LEA(j + len); // start = j + len;
@@ -733,10 +733,10 @@ fn _poly_sub(reg ptr u16[KYBER_N] rp ap bp) -> reg ptr u16[KYBER_N]
 
   i = 0;
   while (i < KYBER_N) {
-    a = ap[(int)i];
-    b = bp[(int)i];
+    a = ap[i];
+    b = bp[i];
     r = a - b;
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -753,9 +753,9 @@ fn _poly_tobytes(reg u64 rp, reg ptr u16[KYBER_N] a) -> reg ptr u16[KYBER_N]
   j = 0;
   while (i < KYBER_N)
   {
-    t0 = a[(int)i]; 
+    t0 = a[i]; 
     i += 1;
-    t1 = a[(int)i]; 
+    t1 = a[i]; 
     i += 1;
     d  = t0;
     d  &= 0xff;

--- a/oldsrc-should-delete/crypto_kem/kyber/common/amd64/ref/polyvec.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/common/amd64/ref/polyvec.jinc
@@ -44,7 +44,7 @@ fn __polyvec_compress(reg u64 rp, stack u16[KYBER_VECN] a)
   {
     for k = 0 to 4
     {
-      t[k] = (64u)aa[(int) i];
+      t[k] = (64u)aa[i];
       i += 1;
       t[k] <<= 10;
       t[k] += 1665;
@@ -107,7 +107,7 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
   {
     for k = 0 to 4
     {
-      t[k] = (64u)aa[(int) i];
+      t[k] = (64u)aa[i];
       i += 1;
       t[k] <<= 10;
       t[k] += 1665;
@@ -118,7 +118,7 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
 
     c = t[0];
     c &= 0xff;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[0];
@@ -126,7 +126,7 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
     c = t[1];
     c <<= 2;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[1];
@@ -134,7 +134,7 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
     c = t[2];
     c <<= 4;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
     
     b = t[2];
@@ -142,12 +142,12 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
     c = t[3];
     c <<= 6;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     
     t[3] >>= 2;
-    rp[(int) j] = t[3];
+    rp[j] = t[3];
     j += 1;
   }
 
@@ -201,7 +201,7 @@ fn __polyvec_decompress(reg u64 ap) -> stack u16[KYBER_VECN]
       t[k] *= KYBER_Q;
       t[k] += 512;
       t[k] >>= 10;
-      r[(int) i] = t[k];
+      r[i] = t[k];
       i += 1;
     }
   }

--- a/oldsrc-should-delete/crypto_kem/kyber/kyber512/amd64/avx2/gen_matrix.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/kyber512/amd64/avx2/gen_matrix.jinc
@@ -298,10 +298,10 @@ fn __rej_uniform(reg ptr u16[KYBER_N] rp, reg u64 offset, reg ptr u8[SHAKE128_RA
 
   while(!b)
   {
-    val0 = (16u)buf[(int)pos];
+    val0 = (16u)buf[pos];
     pos += 1;
 
-    t   = (16u)buf[(int)pos];
+    t   = (16u)buf[pos];
     val1 = t;
     val1 >>= 4;
 
@@ -310,14 +310,14 @@ fn __rej_uniform(reg ptr u16[KYBER_N] rp, reg u64 offset, reg ptr u8[SHAKE128_RA
     val0 |= t;
     pos += 1;
 
-    t   = (16u)buf[(int)pos];
+    t   = (16u)buf[pos];
     t <<= 4;
     val1 |= t;
     pos += 1;
 
     if(val0 < KYBER_Q)
     {
-      rp[(int)ctr] = val0;
+      rp[ctr] = val0;
       ctr += 1;
     }
 
@@ -325,7 +325,7 @@ fn __rej_uniform(reg ptr u16[KYBER_N] rp, reg u64 offset, reg ptr u8[SHAKE128_RA
     {
       if(val1 < KYBER_Q)
       {
-        rp[(int)ctr] = val1;
+        rp[ctr] = val1;
         ctr += 1;
       }
     }
@@ -380,7 +380,7 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
 
   while(!b)
   {
-    f0 = #VPERMQ(buf.[u256 (int)pos], 0x94);
+    f0 = #VPERMQ(buf.[u256 pos], 0x94);
     f1 = #VPERMQ(buf.[u256 24 + (int)pos], 0x94);
     f0 = #VPSHUFB_256(f0, idx8);
     f1 = #VPSHUFB_256(f1, idx8);
@@ -399,22 +399,22 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
 
     t64 = good;
     t64 &= 0xFF;
-    g0 = (256u) #VMOV(idxp[u64 (int)t64]);
+    g0 = (256u) #VMOV(idxp[u64 t64]);
 
     t64_1 = good;
     t64_1 >>= 16;
     t64_1 &= 0xFF;
-    l = #VMOV(idxp[u64 (int)t64_1]);
+    l = #VMOV(idxp[u64 t64_1]);
 
     t64_2 = good;
     t64_2 >>= 8;
     t64_2 &= 0xFF;
-    g1 = (256u) #VMOV(idxp[u64 (int)t64_2]);
+    g1 = (256u) #VMOV(idxp[u64 t64_2]);
 
     t64_3 = good;
     t64_3 >>= 24;
     t64_3 &= 0xFF;
-    h = #VMOV(idxp[u64 (int)t64_3]);
+    h = #VMOV(idxp[u64 t64_3]);
 
     g0 = #VINSERTI128(g0, l, 1);
 
@@ -466,7 +466,7 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
   t64 = 0x5555;
   while(!b)
   {
-    f = buf.[u128 (int)pos];
+    f = buf.[u128 pos];
     f = #VPSHUFB_128(f, idx8);
     t = #VPSRL_8u16(f, 4);
     f = #VPBLEND_8u16(f, t, 0xAA);
@@ -476,7 +476,7 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
     good = #VPMOVMSKB_u128u64(t);
 
     good = #PEXT_64(good, t64);
-    l = #VMOV(idxp[u64 (int)good]);
+    l = #VMOV(idxp[u64 good]);
     _, _, _, _, _, good =  #POPCNT_64(good);
 
     h = #VPADD_16u8(l, ones);
@@ -506,9 +506,9 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
 
   while(!b)
   {
-    val0 = (16u)buf[(int)pos];
+    val0 = (16u)buf[pos];
     pos += 1;
-    t16 = (16u)buf[(int)pos];
+    t16 = (16u)buf[pos];
     pos += 1;
     val1 = t16;
 
@@ -517,21 +517,21 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
     val0 &= 0xFFF;
 
     val1 >>= 4;
-    t16 = (16u)buf[(int)pos];
+    t16 = (16u)buf[pos];
     pos += 1;
     t16 <<= 4;
     val1 |= t16;
 
     if(val0 < KYBER_Q)
     {
-      rp[(int)ctr] = val0;
+      rp[ctr] = val0;
       ctr += 1;
     }
     if(val1 < KYBER_Q)
     {
       if(ctr < KYBER_N)
       {
-        rp[(int)ctr] = val1;
+        rp[ctr] = val1;
         ctr += 1;
       }
     }

--- a/oldsrc-should-delete/crypto_kem/kyber/kyber512/amd64/avx2/indcpa.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/kyber512/amd64/avx2/indcpa.jinc
@@ -82,7 +82,7 @@ fn __indcpa_enc_0(stack u64 sctp, reg ptr u8[KYBER_INDCPA_MSGBYTES] msgp, reg u6
   while (i < KYBER_SYMBYTES/8)
   {
     t64 = (u64)[pkp];
-    publicseed[u64 (int)i] = t64;
+    publicseed[u64 i] = t64;
     pkp += 8;
     i += 1;
   }
@@ -148,7 +148,7 @@ fn __indcpa_enc_1(reg ptr u8[KYBER_INDCPA_BYTES] ctp, reg ptr u8[KYBER_INDCPA_MS
   while (i < KYBER_SYMBYTES/8)
   {
     t64 = (u64)[pkp];
-    publicseed[u64 (int)i] = t64;
+    publicseed[u64 i] = t64;
     pkp += 8;
     i += 1;
   }

--- a/oldsrc-should-delete/crypto_kem/kyber/kyber512/amd64/ref/indcpa.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/kyber512/amd64/ref/indcpa.jinc
@@ -88,7 +88,7 @@ fn __indcpa_enc_0(stack u64 sctp, reg ptr u8[KYBER_INDCPA_MSGBYTES] msgp, reg u6
   while (i < KYBER_SYMBYTES/8)
   {
     t64 = (u64)[pkp];
-    publicseed[u64 (int)i] = t64;
+    publicseed[u64 i] = t64;
     pkp += 8;
     i += 1;
   }
@@ -163,7 +163,7 @@ fn __indcpa_enc_1(reg ptr u8[KYBER_INDCPA_BYTES] ctp, reg ptr u8[KYBER_INDCPA_MS
   while (i < KYBER_SYMBYTES/8)
   {
     t64 = (u64)[pkp];
-    publicseed[u64 (int)i] = t64;
+    publicseed[u64 i] = t64;
     pkp += 8;
     i += 1;
   }

--- a/oldsrc-should-delete/crypto_kem/kyber/kyber768/amd64/avx2/gen_matrix.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/kyber768/amd64/avx2/gen_matrix.jinc
@@ -311,10 +311,10 @@ fn __rej_uniform(reg ptr u16[KYBER_N] rp, reg u64 offset, reg ptr u8[SHAKE128_RA
 
   while(!b)
   {
-    val0 = (16u)buf[(int)pos];
+    val0 = (16u)buf[pos];
     pos += 1;
 
-    t   = (16u)buf[(int)pos];
+    t   = (16u)buf[pos];
     val1 = t;
     val1 >>= 4;
 
@@ -323,14 +323,14 @@ fn __rej_uniform(reg ptr u16[KYBER_N] rp, reg u64 offset, reg ptr u8[SHAKE128_RA
     val0 |= t;
     pos += 1;
 
-    t   = (16u)buf[(int)pos];
+    t   = (16u)buf[pos];
     t <<= 4;
     val1 |= t;
     pos += 1;
 
     if(val0 < KYBER_Q)
     {
-      rp[(int)ctr] = val0;
+      rp[ctr] = val0;
       ctr += 1;
     }
 
@@ -338,7 +338,7 @@ fn __rej_uniform(reg ptr u16[KYBER_N] rp, reg u64 offset, reg ptr u8[SHAKE128_RA
     {
       if(val1 < KYBER_Q)
       {
-        rp[(int)ctr] = val1;
+        rp[ctr] = val1;
         ctr += 1;
       }
     }
@@ -393,7 +393,7 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
 
   while(!b)
   {
-    f0 = #VPERMQ(buf.[u256 (int)pos], 0x94);
+    f0 = #VPERMQ(buf.[u256 pos], 0x94);
     f1 = #VPERMQ(buf.[u256 24 + (int)pos], 0x94);
     f0 = #VPSHUFB_256(f0, idx8);
     f1 = #VPSHUFB_256(f1, idx8);
@@ -412,22 +412,22 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
 
     t64 = good;
     t64 &= 0xFF;
-    g0 = (256u) #VMOV(idxp[u64 (int)t64]);
+    g0 = (256u) #VMOV(idxp[u64 t64]);
 
     t64_1 = good;
     t64_1 >>= 16;
     t64_1 &= 0xFF;
-    l = #VMOV(idxp[u64 (int)t64_1]);
+    l = #VMOV(idxp[u64 t64_1]);
 
     t64_2 = good;
     t64_2 >>= 8;
     t64_2 &= 0xFF;
-    g1 = (256u) #VMOV(idxp[u64 (int)t64_2]);
+    g1 = (256u) #VMOV(idxp[u64 t64_2]);
 
     t64_3 = good;
     t64_3 >>= 24;
     t64_3 &= 0xFF;
-    h = #VMOV(idxp[u64 (int)t64_3]);
+    h = #VMOV(idxp[u64 t64_3]);
 
     g0 = #VINSERTI128(g0, l, 1);
 
@@ -479,7 +479,7 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
   t64 = 0x5555;
   while(!b)
   {
-    f = buf.[u128 (int)pos];
+    f = buf.[u128 pos];
     f = #VPSHUFB_128(f, idx8);
     t = #VPSRL_8u16(f, 4);
     f = #VPBLEND_8u16(f, t, 0xAA);
@@ -489,7 +489,7 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
     good = #VPMOVMSKB_u128u64(t);
 
     good = #PEXT_64(good, t64);
-    l = #VMOV(idxp[u64 (int)good]);
+    l = #VMOV(idxp[u64 good]);
     _, _, _, _, _, good =  #POPCNT_64(good);
 
     h = #VPADD_16u8(l, ones);
@@ -519,9 +519,9 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
 
   while(!b)
   {
-    val0 = (16u)buf[(int)pos];
+    val0 = (16u)buf[pos];
     pos += 1;
-    t16 = (16u)buf[(int)pos];
+    t16 = (16u)buf[pos];
     pos += 1;
     val1 = t16;
 
@@ -530,21 +530,21 @@ fn _rej_uniform_avx(reg ptr u16[KYBER_N] rp, reg ptr u8[REJ_UNIFORM_AVX_BUFLEN] 
     val0 &= 0xFFF;
 
     val1 >>= 4;
-    t16 = (16u)buf[(int)pos];
+    t16 = (16u)buf[pos];
     pos += 1;
     t16 <<= 4;
     val1 |= t16;
 
     if(val0 < KYBER_Q)
     {
-      rp[(int)ctr] = val0;
+      rp[ctr] = val0;
       ctr += 1;
     }
     if(val1 < KYBER_Q)
     {
       if(ctr < KYBER_N)
       {
-        rp[(int)ctr] = val1;
+        rp[ctr] = val1;
         ctr += 1;
       }
     }

--- a/oldsrc-should-delete/crypto_kem/kyber/kyber768/amd64/avx2/indcpa.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/kyber768/amd64/avx2/indcpa.jinc
@@ -85,7 +85,7 @@ fn __indcpa_enc_0(stack u64 sctp, reg ptr u8[KYBER_INDCPA_MSGBYTES] msgp, reg u6
   while (i < KYBER_SYMBYTES/8)
   {
     t64 = (u64)[pkp];
-    publicseed[u64 (int)i] = t64;
+    publicseed[u64 i] = t64;
     pkp += 8;
     i += 1;
   }
@@ -150,7 +150,7 @@ fn __indcpa_enc_1(reg ptr u8[KYBER_INDCPA_BYTES] ctp, reg ptr u8[KYBER_INDCPA_MS
   while (i < KYBER_SYMBYTES/8)
   {
     t64 = (u64)[pkp];
-    publicseed[u64 (int)i] = t64;
+    publicseed[u64 i] = t64;
     pkp += 8;
     i += 1;
   }

--- a/oldsrc-should-delete/crypto_kem/kyber/kyber768/amd64/ref/poly.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/kyber768/amd64/ref/poly.jinc
@@ -26,10 +26,10 @@ fn _poly_add2(reg ptr u16[KYBER_N] rp bp) -> reg ptr u16[KYBER_N]
 
   #bounded
   while (i < KYBER_N) {
-    a = rp[(int)i];
-    b = bp[(int)i];
+    a = rp[i];
+    b = bp[i];
     r = a + b;
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -45,13 +45,13 @@ fn _poly_csubq(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
   #bounded
   while (i < KYBER_N)
   {
-    t = rp[(int)i];
+    t = rp[i];
     t -= KYBER_Q;
     b = t;
     b >>s= 15;
     b &= KYBER_Q;
     t += b;
-    rp[(int)i] = t;
+    rp[i] = t;
     i += 1;
   }
   return rp;
@@ -82,14 +82,14 @@ fn _poly_basemul(reg ptr u16[KYBER_N] rp, reg const ptr u16[KYBER_N] ap bp) -> r
   while(i < KYBER_N)
   {
     zetasp = jzetas;
-    zeta = zetasp[(int)zetasctr];
+    zeta = zetasp[zetasctr];
     zetasctr += 1;
     
-    a0 = ap[(int)i];
-    b0 = bp[(int)i];
+    a0 = ap[i];
+    b0 = bp[i];
     i += 1;
-    a1 = ap[(int)i];
-    b1 = bp[(int)i];
+    a1 = ap[i];
+    b1 = bp[i];
     i -= 1;
 
     r0 = __fqmul(a1, b1);
@@ -102,20 +102,20 @@ fn _poly_basemul(reg ptr u16[KYBER_N] rp, reg const ptr u16[KYBER_N] ap bp) -> r
     r1 += t;
 
     rp = srp;
-    rp[(int)i]   = r0;
+    rp[i]   = r0;
     i += 1;
-    rp[(int)i] = r1;
+    rp[i] = r1;
     srp = rp;
 
 
     zeta = -zeta;
 
     i += 1;
-    a0 = ap[(int)i];
-    b0 = bp[(int)i];
+    a0 = ap[i];
+    b0 = bp[i];
     i += 1;
-    a1 = ap[(int)i];
-    b1 = bp[(int)i];
+    a1 = ap[i];
+    b1 = bp[i];
     i -= 1;
 
     r0 = __fqmul(a1, b1);
@@ -128,9 +128,9 @@ fn _poly_basemul(reg ptr u16[KYBER_N] rp, reg const ptr u16[KYBER_N] ap bp) -> r
     r1 += t;
 
     rp = srp;
-    rp[(int)i]   = r0;
+    rp[i]   = r0;
     i += 1;
-    rp[(int)i] = r1;
+    rp[i] = r1;
     srp = rp;
     
     i += 1;
@@ -147,9 +147,9 @@ fn __poly_reduce(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
   #bounded
   while (j < KYBER_N) 
   {
-    t = rp[(int)j];
+    t = rp[j];
     t = __barrett_reduce(t);
-    rp[(int)j] = t;
+    rp[j] = t;
     j += 1;
   }
   return rp;
@@ -168,7 +168,7 @@ fn _poly_compress(reg u64 rp, reg ptr u16[KYBER_N] a) -> reg ptr u16[KYBER_N]
   #bounded
   while(i < 128)
   {
-    t  = a[(int)j];
+    t  = a[j];
     d0 = (32u)t;
     d0 <<= 4;
     d0 += 1665;
@@ -176,7 +176,7 @@ fn _poly_compress(reg u64 rp, reg ptr u16[KYBER_N] a) -> reg ptr u16[KYBER_N]
     d0 >>= 28;
     d0 &= 0xf;
     j += 1;
-    t  = a[(int)j];
+    t  = a[j];
     d1 = (32u)t;
     d1 <<= 4;
     d1 += 1665;
@@ -205,7 +205,7 @@ fn _i_poly_compress(reg ptr u8[KYBER_POLYCOMPRESSEDBYTES] rp, reg ptr u16[KYBER_
   #bounded
   while(i < 128)
   {
-    t  = a[(int)j];
+    t  = a[j];
     d0 = (32u)t;
     d0 <<= 4;
     d0 += 1665;
@@ -213,7 +213,7 @@ fn _i_poly_compress(reg ptr u8[KYBER_POLYCOMPRESSEDBYTES] rp, reg ptr u16[KYBER_
     d0 >>= 28;
     d0 &= 0xf;
     j += 1;
-    t  = a[(int)j];
+    t  = a[j];
     d1 = (32u)t;
     d1 <<= 4;
     d1 += 1665;
@@ -222,7 +222,7 @@ fn _i_poly_compress(reg ptr u8[KYBER_POLYCOMPRESSEDBYTES] rp, reg ptr u16[KYBER_
     d1 &= 0xf;
     d1 <<= 4;
     d0 |= d1;
-    rp[(int) i] = d0;
+    rp[i] = d0;
     i += 1;
     j += 1;
   }
@@ -252,9 +252,9 @@ fn _poly_decompress(reg ptr u16[KYBER_N] rp, reg u64 ap) -> reg ptr u16[KYBER_N]
     d1 += 8;
     d0 >>= 4;
     d1 >>= 4;
-    rp[(int)j] = d0;
+    rp[j] = d0;
     j += 1;
-    rp[(int)j] = d1;
+    rp[j] = d1;
     j += 1;
     i += 1;
   }
@@ -302,9 +302,9 @@ fn _poly_frommont(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
   #bounded
   while (i < KYBER_N)
   {
-    r = rp[(int)i];
+    r = rp[i];
     r = __fqmul(r, dmont);
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp; 
@@ -462,7 +462,7 @@ fn _poly_getnoise(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_SYMBYTES] seed, reg 
   j = 0;
   #bounded
   while (i < 128) {
-    c = buf[(int)i];
+    c = buf[i];
     a = c;
     a &= 0x55;
 
@@ -477,7 +477,7 @@ fn _poly_getnoise(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_SYMBYTES] seed, reg 
     b &= 0x3;
     a -= b;
     t = (16s)a;
-    rp[(int)j] = t;
+    rp[j] = t;
     a = c;
     a >>= 4;
     a &= 0x3;
@@ -486,7 +486,7 @@ fn _poly_getnoise(reg ptr u16[KYBER_N] rp, reg ptr u8[KYBER_SYMBYTES] seed, reg 
     a -= b;
     t = (16s)a;
     j += 1;
-    rp[(int)j] = t;
+    rp[j] = t;
     i += 1;
     j += 1;
   }
@@ -521,7 +521,7 @@ fn _poly_invntt(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
     #bounded
     while (start < 256)
     {
-      zeta = zetasp[(int)zetasctr];
+      zeta = zetasp[zetasctr];
       zetasctr += 1;
 
       j = start;
@@ -530,14 +530,14 @@ fn _poly_invntt(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
       while (j < cmp)
       {
         offset = #LEA(j + len); // avoid -lea
-        s = rp[(int)offset];
-        t = rp[(int)j];
+        s = rp[offset];
+        t = rp[j];
         m = s; m += t; // valgrind 16 bit lea not implemented
         m = __barrett_reduce(m);
-        rp[(int)j] = m;
+        rp[j] = m;
         t -= s;
         t = __fqmul(t, zeta);
-        rp[(int)offset] = t;
+        rp[offset] = t;
         j += 1;
       }
       start = #LEA(j + len); // avoid -lea
@@ -550,9 +550,9 @@ fn _poly_invntt(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
   #bounded
   while (j < KYBER_N) 
   {
-    t = rp[(int)j];
+    t = rp[j];
     t = __fqmul(t, zeta);
-    rp[(int)j] = t;
+    rp[j] = t;
     j += 1;
   }
   return rp;
@@ -585,21 +585,21 @@ fn _poly_ntt(reg ptr u16[KYBER_N] rp) -> reg ptr u16[KYBER_N]
     while (start < 256)
     {
       zetasctr += 1;
-      zeta = zetasp[(int)zetasctr];
+      zeta = zetasp[zetasctr];
       j = start;
       cmp = #LEA(start + len);
       #bounded
       while (j < cmp)
       {
         offset = #LEA(j + len);
-        t = rp[(int)offset];
+        t = rp[offset];
         t = __fqmul(t, zeta);
-        s = rp[(int)j];
+        s = rp[j];
         m = s;
         m -= t;
-        rp[(int)offset] = m;
+        rp[offset] = m;
         t += s;
-        rp[(int)j] = t;
+        rp[j] = t;
         j += 1;
       }
       start = #LEA(j + len);
@@ -622,10 +622,10 @@ fn _poly_sub(reg ptr u16[KYBER_N] rp ap bp) -> reg ptr u16[KYBER_N]
   i = 0;
   #bounded
   while (i < KYBER_N) {
-    a = ap[(int)i];
-    b = bp[(int)i];
+    a = ap[i];
+    b = bp[i];
     r = a - b;
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -643,9 +643,9 @@ fn _poly_tobytes(reg u64 rp, reg ptr u16[KYBER_N] a) -> reg ptr u16[KYBER_N]
   #bounded
   while (i < KYBER_N)
   {
-    t0 = a[(int)i]; 
+    t0 = a[i]; 
     i += 1;
-    t1 = a[(int)i]; 
+    t1 = a[i]; 
     i += 1;
     d  = t0;
     d  &= 0xff;

--- a/oldsrc-should-delete/crypto_kem/kyber/kyber768/amd64/ref/polyvec.jinc
+++ b/oldsrc-should-delete/crypto_kem/kyber/kyber768/amd64/ref/polyvec.jinc
@@ -39,7 +39,7 @@ fn __polyvec_compress(reg u64 rp, stack u16[KYBER_VECN] a)
   {
     for k = 0 to 4
     {
-      t[k] = (64u)aa[(int) i];
+      t[k] = (64u)aa[i];
       i += 1;
       t[k] <<= 10;
       t[k] += 1665;
@@ -103,7 +103,7 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
   {
     for k = 0 to 4
     {
-      t[k] = (64u)aa[(int) i];
+      t[k] = (64u)aa[i];
       i += 1;
       t[k] <<= 10;
       t[k] += 1665;
@@ -114,7 +114,7 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
 
     c = t[0];
     c &= 0xff;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[0];
@@ -122,7 +122,7 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
     c = t[1];
     c <<= 2;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[1];
@@ -130,7 +130,7 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
     c = t[2];
     c <<= 4;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
     
     b = t[2];
@@ -138,12 +138,12 @@ fn __i_polyvec_compress(reg ptr u8[KYBER_POLYVECCOMPRESSEDBYTES] rp, stack u16[K
     c = t[3];
     c <<= 6;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     
     t[3] >>= 2;
-    rp[(int) j] = t[3];
+    rp[j] = t[3];
     j += 1;
   }
 
@@ -198,7 +198,7 @@ fn __polyvec_decompress(reg u64 ap) -> stack u16[KYBER_VECN]
       t[k] *= KYBER_Q;
       t[k] += 512;
       t[k] >>= 10;
-      r[(int) i] = t[k];
+      r[i] = t[k];
       i += 1;
     }
   }

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/fips202.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/fips202.jinc
@@ -31,7 +31,7 @@ fn __add_full_block(
   while (i < r64)
   {
     t = [in + 8 * i];
-    state[(int) i] ^= t;
+    state[i] ^= t;
     i = i + 1;
   }
 
@@ -60,7 +60,7 @@ fn __add_final_block(
   while ( i < inlen8)
   {
     t = [in + 8*i];
-    state[(int) i] ^= t;
+    state[i] ^= t;
     i = i + 1;
   }
 
@@ -68,15 +68,15 @@ fn __add_final_block(
   while (i < inlen)
   {
     c = (u8)[in + i];
-    state[u8 (int) i] ^= c;
+    state[u8 i] ^= c;
     i = i + 1;
   }
 
-  state[u8 (int) i] ^= trail_byte;
+  state[u8 i] ^= trail_byte;
 
   i = r8;
   i -= 1;
-  state[u8 (int) i] ^= 0x80;
+  state[u8 i] ^= 0x80;
 
   return state;
 }

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/gen_matrix.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/gen_matrix.jinc
@@ -418,14 +418,14 @@ inline fn __gen_matrix_buf_rejection_filter48
   t0_0 = good;
   t0_0 &= 0xFF; // g0[0..7]
 
-  shuffle_0 = (256u) #VMOV(sst[u64 (int)t0_0]);
+  shuffle_0 = (256u) #VMOV(sst[u64 t0_0]);
   ?{}, t0_0 = #POPCNT_64(t0_0);
   t0_0 += counter;  
 
   t0_1 = good;
   t0_1 >>= 16;
   t0_1 &= 0xFF; // g0[8..15]
-  shuffle_0_1 = #VMOV(sst[u64 (int)t0_1]);
+  shuffle_0_1 = #VMOV(sst[u64 t0_1]);
   ?{}, t0_1 = #POPCNT_64(t0_1);
   t0_1 += t0_0;
 
@@ -433,14 +433,14 @@ inline fn __gen_matrix_buf_rejection_filter48
   t1_0 = good;
   t1_0 >>= 8;
   t1_0 &= 0xFF; // g1[0..7]
-  shuffle_1 = (256u) #VMOV(sst[u64 (int)t1_0]);
+  shuffle_1 = (256u) #VMOV(sst[u64 t1_0]);
   ?{}, t1_0 = #POPCNT_64(t1_0);
   t1_0 += t0_1;
 
   t1_1 = good;
   t1_1 >>= 24;
   t1_1 &= 0xFF; // g1[8..15]
-  shuffle_1_1 = #VMOV(sst[u64 (int)t1_1]);
+  shuffle_1_1 = #VMOV(sst[u64 t1_1]);
   ?{}, t1_1 = #POPCNT_64(t1_1);
   t1_1 += t1_0;
 
@@ -560,14 +560,14 @@ inline fn __gen_matrix_buf_rejection_filter24
   // g0
   t0_0 = good;
   t0_0 &= 0xFF; // g0[0..7]
-  shuffle_0 = (256u) #VMOV(sst[u64 (int)t0_0]);
+  shuffle_0 = (256u) #VMOV(sst[u64 t0_0]);
   ?{}, t0_0 = #POPCNT_64(t0_0);
   t0_0 += counter;
 
   t0_1 = good;
   t0_1 >>= 16;
   t0_1 &= 0xFF; // g0[8..15]
-  shuffle_0_1 = #VMOV(sst[u64 (int)t0_1]);
+  shuffle_0_1 = #VMOV(sst[u64 t0_1]);
   ?{}, t0_1 = #POPCNT_64(t0_1);
   t0_1 += t0_0;
 

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/keccak/keccakf1600.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/keccak/keccakf1600.jinc
@@ -142,7 +142,7 @@ inline fn __keccakf1600(reg ptr u64[25] a) -> reg ptr u64[25]
   c = 0;
   while (c < KECCAK_ROUNDS - 1)
   {
-    rc = RC[(int) c];
+    rc = RC[c];
     e = keccakf1600_round(e, a, rc);
 
     rc = RC[(int) c + 1];

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/keccak/keccakf1600_4x_avx2_compact.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/keccak/keccakf1600_4x_avx2_compact.jinc
@@ -190,7 +190,7 @@ inline fn __keccakf1600_4x(reg ptr u256[25] a) -> reg ptr u256[25]
   c = 0;
   while(c < (KECCAK_ROUNDS*32))
   {
-    rc = RC.[(int) c];
+    rc = RC.[c];
     e = keccakf1600_4x_round(e, a, rc, r8, r56);
 
     // just an expensive pointer swap (#todo request feature)

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/keccak/keccakf1600_avx2.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/keccak/keccakf1600_avx2.jinc
@@ -181,7 +181,7 @@ fn _keccakf1600_avx2(reg u256[7] state) -> reg u256[7]
     state[4] = state[4] ^ t[4];
 
     //######################################## Iota
-    state[0] = state[0] ^ iotas_p.[(int) iotas_o];
+    state[0] = state[0] ^ iotas_p.[iotas_o];
     iotas_o += 32;
 
     _,_,_,zf,r = #DEC_64(r);

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/verify.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/avx2/verify.jinc
@@ -59,7 +59,7 @@ fn __cmov(reg u64 dst, reg ptr u8[MLKEM_SYMBYTES] src, reg u64 cnd)
   {
     f = src.[u256 32*i];
     g = (u256)[dst + 32*i];
-    f = #VPBLENDVB_256(f, g, m);
+    f = #BLENDV_32u8(f, g, m);
     (u256)[dst + 32*i] = f;
   }
 

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/ref/fips202.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/ref/fips202.jinc
@@ -208,7 +208,7 @@ inline fn __keccakf1600(reg ptr u64[25] a) -> reg ptr u64[25]
   c = 0;
   while (c < KECCAK_ROUNDS - 1)
   {
-    rc = RC[(int) c];
+    rc = RC[c];
     e = keccakf1600_round(e, a, rc);
 
     rc = RC[(int) c + 1];
@@ -263,7 +263,7 @@ fn __add_full_block(
   while (i < r64)
   {
     t = [in + 8 * i];
-    state[(int) i] ^= t;
+    state[i] ^= t;
     i = i + 1;
   }
 
@@ -292,7 +292,7 @@ fn __add_final_block(
   while ( i < inlen8)
   {
     t = [in + 8*i];
-    state[(int) i] ^= t;
+    state[i] ^= t;
     i = i + 1;
   }
 
@@ -300,15 +300,15 @@ fn __add_final_block(
   while (i < inlen)
   {
     c = (u8)[in + i];
-    state[u8 (int) i] ^= c;
+    state[u8 i] ^= c;
     i = i + 1;
   }
 
-  state[u8 (int) i] ^= trail_byte;
+  state[u8 i] ^= trail_byte;
 
   i = r8;
   i -= 1;
-  state[u8 (int) i] ^= 0x80;
+  state[u8 i] ^= 0x80;
 
   return state;
 }
@@ -329,7 +329,7 @@ fn __xtr_full_block(
   i = 0;
   while (i < rate64)
   {
-    t = state[(int) i];
+    t = state[i];
     [out + 8 * i] = t;
     i = i + 1;
   }
@@ -356,7 +356,7 @@ fn ____xtr_bytes(
   i = 0;
   while (i < outlen8 )
   {
-    t = state[(int) i];
+    t = state[i];
     [out + 8 * i] = t;
     i = i + 1;
   }
@@ -364,7 +364,7 @@ fn ____xtr_bytes(
 
   while (i < outlen)
   {
-    c = state[u8 (int) i];
+    c = state[u8 i];
     (u8)[out + i] = c;
     i = i + 1;
   }
@@ -489,7 +489,7 @@ fn _shake256_128_33(#spill_to_mmx reg ptr u8[128] out, reg const ptr u8[33] in) 
   () = #unspill(out);
 
   for i = 0 to 128 {
-    c = state[u8 (int) i];
+    c = state[u8 i];
     out[i] = c;
   }
   return out;
@@ -575,7 +575,7 @@ fn _sha3512_32(#spill_to_mmx reg ptr u8[64] out, reg const ptr u8[32] in) -> reg
   () = #unspill(out);
 
   for i = 0 to 64 {
-    c = state[u8 (int) i];
+    c = state[u8 i];
     out[i] = c;
   }
 
@@ -613,7 +613,7 @@ fn _shake128_squeezeblock(reg ptr u64[25] state, #spill_to_mmx reg ptr u8[SHAKE1
   () = #unspill(out);
 
   for i = 0 to SHAKE128_RATE { // SHAKE128 rate is 168: or 21 u64: TODO: 'compress' this for loop
-    c = state[u8 (int) i];
+    c = state[u8 i];
     out[i] = c;
   }
   return state, out;

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/ref/gen_matrix.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/ref/gen_matrix.jinc
@@ -136,7 +136,7 @@ fn __gen_matrix(stack u8[MLKEM_SYMBYTES] seed, reg u64 transposed) -> stack u16[
       rij = r[i * MLKEM_VECN + j * MLKEM_N : MLKEM_N];
       while (k < MLKEM_N)
       {
-        t = poly[(int) k];
+        t = poly[k];
         rij[k] = t;
         k += 1;
       }

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/ref/poly.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/ref/poly.jinc
@@ -13,10 +13,10 @@ fn _poly_add2(reg ptr u16[MLKEM_N] rp bp) -> reg ptr u16[MLKEM_N]
   i = 0;
 
   while (i < MLKEM_N) {
-    a = rp[(int)i];
-    b = bp[(int)i];
+    a = rp[i];
+    b = bp[i];
     r = a + b;
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -31,13 +31,13 @@ fn _poly_csubq(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
   i = 0;
   while (i < MLKEM_N)
   {
-    t = rp[(int)i];
+    t = rp[i];
     t -= MLKEM_Q;
     b = t;
     b >>s= 15;
     b &= MLKEM_Q;
     t += b;
-    rp[(int)i] = t;
+    rp[i] = t;
     i += 1;
   }
   return rp;
@@ -70,11 +70,11 @@ fn _poly_basemul(reg ptr u16[MLKEM_N] rp, reg const ptr u16[MLKEM_N] ap bp) -> r
     zetasctr >>= 2;
     zeta = zetasp[zetasctr];
     
-    a0 = ap[(int)i];
-    b0 = bp[(int)i];
+    a0 = ap[i];
+    b0 = bp[i];
     i += 1;
-    a1 = ap[(int)i];
-    b1 = bp[(int)i];
+    a1 = ap[i];
+    b1 = bp[i];
     i -= 1;
 
     r0 = __fqmul(a1, b1);
@@ -87,20 +87,20 @@ fn _poly_basemul(reg ptr u16[MLKEM_N] rp, reg const ptr u16[MLKEM_N] ap bp) -> r
     r1 += t;
 
     rp = srp;
-    rp[(int)i]   = r0;
+    rp[i]   = r0;
     i += 1;
-    rp[(int)i] = r1;
+    rp[i] = r1;
     srp = rp;
 
 
     zeta = -zeta;
 
     i += 1;
-    a0 = ap[(int)i];
-    b0 = bp[(int)i];
+    a0 = ap[i];
+    b0 = bp[i];
     i += 1;
-    a1 = ap[(int)i];
-    b1 = bp[(int)i];
+    a1 = ap[i];
+    b1 = bp[i];
     i -= 1;
 
     r0 = __fqmul(a1, b1);
@@ -113,9 +113,9 @@ fn _poly_basemul(reg ptr u16[MLKEM_N] rp, reg const ptr u16[MLKEM_N] ap bp) -> r
     r1 += t;
 
     rp = srp;
-    rp[(int)i]   = r0;
+    rp[i]   = r0;
     i += 1;
-    rp[(int)i] = r1;
+    rp[i] = r1;
     srp = rp;
     
     i += 1;
@@ -131,9 +131,9 @@ fn __poly_reduce(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
   j = 0;
   while (j < MLKEM_N) 
   {
-    t = rp[(int)j];
+    t = rp[j];
     t = __barrett_reduce(t);
-    rp[(int)j] = t;
+    rp[j] = t;
     j += 1;
   }
   return rp;
@@ -267,9 +267,9 @@ fn _poly_frommont(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
   i = 0;
   while (i < MLKEM_N)
   {
-    r = rp[(int)i];
+    r = rp[i];
     r = __fqmul(r, dmont);
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp; 
@@ -479,22 +479,22 @@ fn _poly_invntt(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
     start = 0;
     while (start < 256)
     {
-      zeta = zetasp[(int)zetasctr];
+      zeta = zetasp[zetasctr];
       zetasctr += 1;
 
       j = start;
       cmp = start; cmp += len;
       while (j < cmp)
       {
-        t = rp[(int)j];
+        t = rp[j];
         offset = j; offset += len;
-        s = rp[(int)offset];
+        s = rp[offset];
         m = s; m += t;
         m = __barrett_reduce(m);
-        rp[(int)j] = m;
+        rp[j] = m;
         t -= s;
         t = __fqmul(t, zeta);
-        rp[(int)offset] = t;
+        rp[offset] = t;
         j += 1;
       }
       start = j; start += len;
@@ -506,9 +506,9 @@ fn _poly_invntt(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
   j = 0;
   while (j < MLKEM_N) 
   {
-    t = rp[(int)j];
+    t = rp[j];
     t = __fqmul(t, zeta);
-    rp[(int)j] = t;
+    rp[j] = t;
     j += 1;
   }
   return rp;
@@ -539,20 +539,20 @@ fn _poly_ntt(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
     while (start < 256)
     {
       zetasctr += 1;
-      zeta = zetasp[(int)zetasctr];
+      zeta = zetasp[zetasctr];
       j = start;
       cmp = start; cmp += len;
       while (j < cmp)
       {
-        s = rp[(int)j];
+        s = rp[j];
         m = s;
         offset = j; offset += len;
-        t = rp[(int)offset];
+        t = rp[offset];
         t = __fqmul(t, zeta);
         m -= t;
         t += s;
-        rp[(int)offset] = m;
-        rp[(int)j] = t;
+        rp[offset] = m;
+        rp[j] = t;
         j += 1;
       }
       start = j; start += len;
@@ -574,10 +574,10 @@ fn _poly_sub(reg ptr u16[MLKEM_N] rp ap bp) -> reg ptr u16[MLKEM_N]
 
   i = 0;
   while (i < MLKEM_N) {
-    a = ap[(int)i];
-    b = bp[(int)i];
+    a = ap[i];
+    b = bp[i];
     r = a - b;
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -594,9 +594,9 @@ fn _poly_tobytes(reg u64 rp, reg ptr u16[MLKEM_N] a) -> reg ptr u16[MLKEM_N]
   j = 0;
   while (i < MLKEM_N)
   {
-    t0 = a[(int)i]; 
+    t0 = a[i]; 
     i += 1;
-    t1 = a[(int)i]; 
+    t1 = a[i]; 
     i += 1;
     d  = t0;
     d  &= 0xff;

--- a/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/ref/polyvec.jinc
+++ b/oldsrc-should-delete/crypto_kem/mlkem/mlkem768/amd64/ref/polyvec.jinc
@@ -39,7 +39,7 @@ fn __polyvec_compress(reg u64 rp, stack u16[MLKEM_VECN] a)
   {
     for k = 0 to 4
     {
-      t[k] = (64u)aa[(int) i];
+      t[k] = (64u)aa[i];
       i += 1;
       t[k] <<= 10;
       t[k] += 1665;
@@ -102,7 +102,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
   {
     for k = 0 to 4
     {
-      t[k] = (64u)aa[(int) i];
+      t[k] = (64u)aa[i];
       i += 1;
       t[k] <<= 10;
       t[k] += 1665;
@@ -113,7 +113,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
 
     c = t[0];
     c &= 0xff;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[0];
@@ -121,7 +121,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
     c = t[1];
     c <<= 2;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[1];
@@ -129,7 +129,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
     c = t[2];
     c <<= 4;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
     
     b = t[2];
@@ -137,12 +137,12 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
     c = t[3];
     c <<= 6;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     
     t[3] >>= 2;
-    rp[(int) j] = t[3];
+    rp[j] = t[3];
     j += 1;
   }
 
@@ -196,7 +196,7 @@ fn __polyvec_decompress(reg u64 ap) -> stack u16[MLKEM_VECN]
       t[k] *= MLKEM_Q;
       t[k] += 512;
       t[k] >>= 10;
-      r[(int) i] = t[k];
+      r[i] = t[k];
       i += 1;
     }
   }

--- a/oldsrc-should-delete/crypto_onetimeauth/poly1305/amd64/ref/poly1305.jinc
+++ b/oldsrc-should-delete/crypto_onetimeauth/poly1305/amd64/ref/poly1305.jinc
@@ -38,11 +38,11 @@ inline fn __load_last_add(reg u64[3] h, reg u64 in len) -> reg u64[3]
   j = 0;
   while(j < len)
   { c = (u8)[in + j];
-    s[u8 (int)j] = c;
+    s[u8 j] = c;
     j += 1;
   }
 
-  s[u8 (int)j] = 0x1;
+  s[u8 j] = 0x1;
 
   cf, h[0] += s[0];
   cf, h[1] += s[1] + cf;

--- a/oldsrc-should-delete/crypto_scalarmult/curve25519/amd64/mulx/scalarmult.jazz
+++ b/oldsrc-should-delete/crypto_scalarmult/curve25519/amd64/mulx/scalarmult.jazz
@@ -6,7 +6,7 @@ inline fn __ith_bit(stack u8[32] k, reg u64 ctr) -> reg u64
 
   p = ctr;
   p >>= 3;
-  bit = (64u) k[(int) p];
+  bit = (64u) k[p];
 
   p = ctr;
   p &= 7;

--- a/oldsrc-should-delete/crypto_scalarmult/curve25519/amd64/ref4/scalarmult.jazz
+++ b/oldsrc-should-delete/crypto_scalarmult/curve25519/amd64/ref4/scalarmult.jazz
@@ -6,7 +6,7 @@ inline fn __ith_bit(stack u8[32] k, reg u64 ctr) -> reg u64
 
   p = ctr;
   p >>= 3;
-  bit = (64u) k[(int) p];
+  bit = (64u) k[p];
 
   p = ctr;
   p &= 7;

--- a/oldsrc-should-delete/crypto_scalarmult/curve25519/amd64/ref5/scalarmult.jazz
+++ b/oldsrc-should-delete/crypto_scalarmult/curve25519/amd64/ref5/scalarmult.jazz
@@ -6,7 +6,7 @@ inline fn __ith_bit(stack u8[32] k, reg u64 ctr) -> reg u64
 
   p = ctr;
   p >>= 3;
-  bit = (64u) k[(int) p];
+  bit = (64u) k[p];
 
   p = ctr;
   p &= 7;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/expandA.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/expandA.jinc
@@ -59,7 +59,7 @@ fn expandA_poly_extract(reg ptr u32[Li2_polydeg] poly,
 			v64_1 = xof_offset;
 			v64_2 = lane;
 			addr = expandA_xof_buf_addr(v64_1, v64_2);
-			vs[ii] = (32u) xof[u8 (int) addr];
+			vs[ii] = (32u) xof[u8 addr];
 			xof_offset += 1;
 		}
 
@@ -74,7 +74,7 @@ fn expandA_poly_extract(reg ptr u32[Li2_polydeg] poly,
 		coeff &= 0x7FFFFF;
 		if coeff < Li2_q {
 			addr = coeffs_filled;
-			poly[(int) addr] = coeff;
+			poly[addr] = coeff;
 			coeffs_filled += 1;
 			if coeffs_filled >= Li2_polydeg {
 				yield = 1;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/expandMask.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/expandMask.jinc
@@ -33,8 +33,8 @@ fn expandMask_poly_shake_init(stack u64[25] state, reg ptr u8[64] rho_prime, sta
 	state = st0(state);
 	i = 0;
 	while (i < 64) {
-		c = rho_prime[(int) i];
-		state[u8 (int) i] = c;
+		c = rho_prime[i];
+		state[u8 i] = c;
 		i += 1;
 	}
 
@@ -129,12 +129,12 @@ fn expandMask_poly_gamma1_217_4x(
 				addr = i;
 				v64 = j;
 				addr = expandMask_xof_addr(addr, v64);
-				c = xof[u8 (int) addr];
+				c = xof[u8 addr];
 				addr = y_packed_buflen_gamma1_217;
 				addr *= j;
 				addr += y_packed_filled;
 				addr += i;
-				y_packed[(int) addr] = c;
+				y_packed[addr] = c;
 				j += 1;
 			}
 			i += 1;
@@ -204,12 +204,12 @@ fn expandMask_poly_gamma1_219_4x(
 				addr = i;
 				v64 = j;
 				addr = expandMask_xof_addr(addr, v64);
-				c = xof[u8 (int) addr];
+				c = xof[u8 addr];
 				addr = y_packed_buflen_gamma1_219;
 				addr *= j;
 				addr += y_packed_filled;
 				addr += i;
-				y_packed[(int) addr] = c;
+				y_packed[addr] = c;
 				j += 1;
 			}
 			i += 1;
@@ -259,9 +259,9 @@ fn expandMask_poly_gamma1_219(reg ptr u32[Li2_polydeg] f, reg ptr u8[64] rho_pri
 		i = 0;
 		while(i < SHAKE256_RATE) {
 			addr = i;
-			c = state[u8 (int) addr];
+			c = state[u8 addr];
 			addr = y_loc;
-			y_packed[(int) addr] = c;
+			y_packed[addr] = c;
 			y_loc += 1;
 			i += 1;
 		}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/expandMask_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/expandMask_end.jinc
@@ -25,11 +25,11 @@ fn expandMask_buffered(
 			addr = buffer_offset;
 			addr <<= Li2_log2polydeg;
 			addr += i;
-			v32 = buffer[(int) addr];
+			v32 = buffer[addr];
 			addr = polys_generated;
 			addr <<= Li2_log2polydeg;
 			addr += i;
-			y[(int) addr] = v32;
+			y[addr] = v32;
 			i += 1;
 		}
 		buffer_offset += 1;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/keccak1600.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/keccak1600.jinc
@@ -47,8 +47,8 @@ inline fn __add_full_block_avx2(
   while ( j < rate8 )
   {
     t = [in + 8*j];
-    l = a_jagged_p[(int) j];
-    s_state[(int) l] = t;
+    l = a_jagged_p[j];
+    s_state[l] = t;
     j += 1;
   }
 
@@ -90,33 +90,33 @@ inline fn __add_final_block_avx2(
   while ( j < inlen8 )
   {
     t = [in + 8*j];
-    l = a_jagged_p[(int) j];
-    s_state[(int) l] = t;
+    l = a_jagged_p[j];
+    s_state[l] = t;
     j += 1;
   }
-  l = a_jagged_p[(int) j];
+  l = a_jagged_p[j];
   l <<= 3;
   j <<= 3;
 
   while ( j < inlen )
   {
     c = (u8)[in + j];
-    s_state[u8 (int) l] = c;
+    s_state[u8 l] = c;
     j += 1;
     l += 1;
   }
 
-  s_state[u8 (int) l] = trail_byte;
+  s_state[u8 l] = trail_byte;
 
   // j  = (rate-1) >> 3;
   j = rate; j -= 1; j >>= 3;
-  l  = a_jagged_p[(int) j];
+  l  = a_jagged_p[j];
   l <<= 3;
   // l += ((rate-1) & 0x7)
   j = rate; j -= 1; j &= 0x7;
   l += j;
 
-  s_state[u8 (int) l] ^= 0x80;
+  s_state[u8 l] ^= 0x80;
 
   t = s_state[0];
   s_state[1] = t;
@@ -151,8 +151,8 @@ inline fn __xtr_full_block_avx2(
   j = 0;
   while ( j < len8 )
   {
-    l = a_jagged_p[(int) j];
-    t = s_state[(int) l];
+    l = a_jagged_p[j];
+    t = s_state[l];
     [out + 8*j] = t;
     j += 1;
   }
@@ -183,18 +183,18 @@ inline fn __xtr_bytes_avx2(
   len8 >>= 3;
   j = 0;
   while ( j < len8 )
-  { l = a_jagged_p[(int) j];
-    t = s_state[(int) l];
+  { l = a_jagged_p[j];
+    t = s_state[l];
     [out + 8*j] = t;
     j += 1;
   }
-  l = a_jagged_p[(int)j];
+  l = a_jagged_p[j];
   j <<= 3;
   l <<= 3;
 
   while ( j < len )
   {
-    c = s_state[u8 (int) l];
+    c = s_state[u8 l];
     (u8)[out + j] = c;
     j += 1;
     l += 1;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/keccakf1600.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/keccakf1600.jinc
@@ -190,7 +190,7 @@ inline fn __keccakf1600_avx2(reg u256[7] state) -> reg u256[7]
 	  state[4] = state[4] ^ t[4];
 
 	  //######################################## Iota
-	  state[0] = state[0] ^ iotas_p.[(int) iotas_o];
+	  state[0] = state[0] ^ iotas_p.[iotas_o];
     iotas_o += 32;
 
     _,_,_,zf,r = #DEC_64(r);

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/poly.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/poly.jinc
@@ -20,9 +20,9 @@ fn poly_add(reg ptr u32[Li2_polydeg] f g result)
 
 	?{}, offset = #set0_64();
 	while (offset < 4 * Li2_polydeg) {
-		v256 = #VMOVDQU_256(f.[u256 (int) offset]);
-		v256 = #VPADD_8u32(v256, g.[u256 (int) offset]);
-		#VMOVDQU_256(result.[u256 (int) offset]) = v256;
+		v256 = #VMOVDQU_256(f.[u256 offset]);
+		v256 = #VPADD_8u32(v256, g.[u256 offset]);
+		#VMOVDQU_256(result.[u256 offset]) = v256;
 
 		offset += 32;
 	}
@@ -37,9 +37,9 @@ fn poly_subtract(reg ptr u32[Li2_polydeg] f g result)
 
 	?{}, offset = #set0_64();
 	while (offset < 4 * Li2_polydeg) {
-		v256 = #VMOVDQU_256(f.[u256 (int) offset]);
-		v256 = #VPSUB_8u32(v256, g.[u256 (int) offset]);
-		#VMOVDQU_256(result.[u256 (int) offset]) = v256;
+		v256 = #VMOVDQU_256(f.[u256 offset]);
+		v256 = #VPSUB_8u32(v256, g.[u256 offset]);
+		#VMOVDQU_256(result.[u256 offset]) = v256;
 
 		offset += 32;
 	}
@@ -54,9 +54,9 @@ fn poly_accumulate(reg ptr u32[Li2_polydeg] f acc)
 
 	?{}, offset = #set0_64();
 	while (offset < 4 * Li2_polydeg) {
-		v256 = #VMOVDQU_256(acc.[u256 (int) offset]);
-		v256 = #VPADD_8u32(v256, f.[u256 (int) offset]);
-		#VMOVDQU_256(acc.[u256 (int) offset]) = v256;
+		v256 = #VMOVDQU_256(acc.[u256 offset]);
+		v256 = #VPADD_8u32(v256, f.[u256 offset]);
+		#VMOVDQU_256(acc.[u256 offset]) = v256;
 
 		offset += 32;
 	}
@@ -77,13 +77,13 @@ fn poly_reduce32(reg ptr u32[Li2_polydeg] poly)
 	?{}, offset = #set0_64();
 	while(offset < 4 * Li2_polydeg) {
 		// t = (a + (1 << 22)) >> 23
-		a = #VMOVDQU_256(poly.[u256 (int) offset]);
+		a = #VMOVDQU_256(poly.[u256 offset]);
 		t = #VPADD_8u32(a, const_2_22);
 		t = #VPSRA_8u32(t, 23);
 		// t = a - t*Q
 		t = #VPMULL_8u32(t, q);
 		a = #VPSUB_8u32(a, t);
-		#VMOVDQU_256(poly.[u256 (int) offset]) = a;
+		#VMOVDQU_256(poly.[u256 offset]) = a;
 
 		offset += 32;
 	}
@@ -111,8 +111,8 @@ fn poly_pointwise_montgomery(reg ptr u32[Li2_polydeg] fft_f fft_g fft_prod)
 
 	?{}, offset = #set0_64();
 	while (offset < 4 * Li2_polydeg) {
-		f_lo = #VMOVDQU_256(fft_f.[u256 (int) offset]);
-		g_lo = #VMOVDQU_256(fft_g.[u256 (int) offset]);
+		f_lo = #VMOVDQU_256(fft_f.[u256 offset]);
+		g_lo = #VMOVDQU_256(fft_g.[u256 offset]);
 		f_hi = #VMOVSHDUP_256(f_lo);
 		g_hi = #VMOVSHDUP_256(g_lo);
 
@@ -130,7 +130,7 @@ fn poly_pointwise_montgomery(reg ptr u32[Li2_polydeg] fft_f fft_g fft_prod)
 
 		prod_lo = #VMOVSHDUP_256(prod_lo);
 		prod_lo = #VPBLEND_8u32(prod_lo, prod_hi, 0xAA);
-		#VMOVDQU_256(fft_prod.[u256 (int) offset]) = prod_lo;
+		#VMOVDQU_256(fft_prod.[u256 offset]) = prod_lo;
 
 		offset += 32;
 	}
@@ -147,7 +147,7 @@ fn zero_poly(reg ptr u32[Li2_polydeg] f)
 	?{}, offset = #set0_64();
 
 	while (offset < 4 * Li2_polydeg) {
-		#VMOVDQU_256(f.[u256 (int) offset]) = zero;
+		#VMOVDQU_256(f.[u256 offset]) = zero;
 		offset += 32;
 	}
 	return f;
@@ -164,11 +164,11 @@ fn poly_caddq(reg ptr u32[Li2_polydeg] poly)
 	
 	?{}, offset = #set0_64();
 	while (offset < 4 * Li2_polydeg) {
-		v256 = #VMOVDQU_256(poly.[u256 (int) offset]);
+		v256 = #VMOVDQU_256(poly.[u256 offset]);
 		mask = #VPCMPGT_8u32(zero, v256);
 		add = #VPAND_256(q, mask);
 		v256 = #VPADD_8u32(v256, add);
-		#VMOVDQU_256(poly.[u256 (int) offset]) = v256;
+		#VMOVDQU_256(poly.[u256 offset]) = v256;
 
 		offset += 32;
 	}
@@ -197,7 +197,7 @@ fn poly_checknorm(reg ptr u32[Li2_polydeg] poly, inline int threshold)
 
 	?{}, offset = #set0_64();
 	while (offset < 4 * Li2_polydeg) {
-		v256 = #VMOVDQU_256(poly.[u256 (int) offset]);
+		v256 = #VMOVDQU_256(poly.[u256 offset]);
 		exceeds_pos = #VPCMPGT_8u32(v256, v256_threshold);
 		v256 = #VPSUB_8u32(v256_zero, v256);
 		exceeds_neg = #VPCMPGT_8u32(v256, v256_threshold);

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/poly_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/poly_end.jinc
@@ -11,17 +11,17 @@ fn poly_make_hint(reg ptr u32[Li2_polydeg] f0 f1 hints)
 
 	i = 0;
 	while(i < Li2_polydeg) {
-		hints[(int) i] = 0;
+		hints[i] = 0;
 		i += 1;
 	}
 
 	weight = 0;
 	i = 0;
 	while(i < Li2_polydeg) {
-		a0 = f0[(int) i];
-		a1 = f1[(int) i];
+		a0 = f0[i];
+		a1 = f1[i];
 		h = make_hint(a0, a1);
-		hints[(int) i] = h;
+		hints[i] = h;
 		weight += h;
 		i += 1;
 	}
@@ -37,10 +37,10 @@ fn poly_use_hint(reg ptr u32[Li2_polydeg] w1 hints)
 
 	i = 0;
 	while (i < Li2_polydeg) {
-		h = hints[(int) i];
-		a = w1[(int) i];
+		h = hints[i];
+		a = w1[i];
 		a = use_hint(a, h);
-		w1[(int) i] = a;
+		w1[i] = a;
 		i += 1;
 	}
 	return w1;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/polyvec_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/polyvec_end.jinc
@@ -9,9 +9,9 @@ fn reduce32_vecl(reg ptr u32[Li2_l * Li2_polydeg] vec)
 
 	?{}, i = #set0_64();
 	while(i < Li2_l * Li2_polydeg) {
-		val = vec[(int) i];
+		val = vec[i];
 		res = reduce32(val);
-		vec[(int) i] = res;
+		vec[i] = res;
 		i += 1;
 	}
 
@@ -26,9 +26,9 @@ fn reduce32_veck(reg ptr u32[Li2_k * Li2_polydeg] vec)
 
 	?{}, i = #set0_64();
 	while(i < Li2_k * Li2_polydeg) {
-		val = vec[(int) i];
+		val = vec[i];
 		res = reduce32(val);
-		vec[(int) i] = res;
+		vec[i] = res;
 		i += 1;
 	}
 
@@ -107,10 +107,10 @@ fn power2round_vec(reg ptr u32[Li2_k * Li2_polydeg] v)
 
 	?{}, i = #set0_64();
 	while(i < Li2_k * Li2_polydeg) {
-		x = v[(int) i];
+		x = v[i];
 		y1, y2 = power2round(x);
-		t1[(int) i] = y1;
-		t0[(int) i] = y2;
+		t1[i] = y1;
+		t0[i] = y2;
 		i += 1;
 	}
 
@@ -244,13 +244,13 @@ fn pointwise_mont_mult(reg ptr u32[Li2_polydeg] f g fg)
 	reg u32 prod_redc;
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		v32 = f[(int) i];
+		v32 = f[i];
 		result = (64s) v32;
-		v32 = g[(int) i];
+		v32 = g[i];
 		gv_64 = (64s) v32;
 		result *= gv_64;
 		prod_redc = montgomery_REDC(result);
-		fg[(int) i] = prod_redc;
+		fg[i] = prod_redc;
 		i += 1;
 	}
 	return fg;
@@ -267,8 +267,8 @@ fn deep_copy_vecl(reg ptr u32[Li2_l * Li2_polydeg] vec)
 
 	?{}, i = #set0_64();
 	while(i < Li2_l * Li2_polydeg) {
-		entry = vec[(int) i];
-		dest[(int) i] = entry;
+		entry = vec[i];
+		dest[i] = entry;
 		i += 1;
 	}
 	return dest;
@@ -286,13 +286,13 @@ fn decompose_vec(reg ptr u32[Li2_k * Li2_polydeg] vec)
 	?{}, i = #set0_64();
 	while(i < Li2_k * Li2_polydeg) {
 		addr = i;
-		a = vec[(int) addr];
+		a = vec[addr];
 
 		a0, a1 = decompose(a);
 
 		addr = i;
-		vec0[(int) addr] = a0;
-		vec1[(int) addr] = a1;
+		vec0[addr] = a0;
+		vec1[addr] = a1;
 
 		i += 1;
 	}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/sign_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/avx2/sign_end.jinc
@@ -21,15 +21,15 @@ fn compute_rho_prime(reg ptr u8[32] k, reg ptr u8[64] mu)
 	state = st0(state);
 	?{}, i = #set0_64();
 	while(i < 32) {
-		c = k[(int) i];
-		state[u8 (int) i] = c;	
+		c = k[i];
+		state[u8 i] = c;	
 		i += 1;
 	}
 	while(i < 96) {
 		mu_loc = i;
 		mu_loc -= 32;
-		c = mu[(int) mu_loc];
-		state[u8 (int) i] = c;
+		c = mu[mu_loc];
+		state[u8 i] = c;
 		i += 1;
 	}
 
@@ -40,8 +40,8 @@ fn compute_rho_prime(reg ptr u8[32] k, reg ptr u8[64] mu)
 
 	?{}, i = #set0_64();
 	while(i < 64) {
-		c = state[u8 (int) i];
-		rho_prime[(int) i] = c;
+		c = state[u8 i];
+		rho_prime[i] = c;
 		i += 1;
 	}
 	return rho_prime;
@@ -219,7 +219,7 @@ fn sign(reg u64 ptr_signature, reg u64 ptr_m, reg u64 m_len, reg u64 ptr_sk) -> 
 	?{}, i = #set0_64();
 	while(i < Li2_SK_LEN) {
 		c = (u8)[ptr_sk + i];
-		sk[(int) i] = c;
+		sk[i] = c;
 		i += 1;
 	}
 	
@@ -229,7 +229,7 @@ fn sign(reg u64 ptr_signature, reg u64 ptr_m, reg u64 m_len, reg u64 ptr_sk) -> 
 	
 	?{}, i = #set0_64();
 	while(i < Li2_SIGN_LEN) {
-		c = signature[(int) i];
+		c = signature[i];
 		(u8) [sig_addr + i] = c;
 		i += 1;
 	}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/expandA_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/expandA_end.jinc
@@ -36,7 +36,7 @@ fn expandA_poly(reg ptr u8[32] rho, inline int i, inline int j,
 				state_rsp = __keccakf1600_ref(state_rsp);
 				offset = 0;
 			}
-			c = state_rsp[u8 (int) offset];
+			c = state_rsp[u8 offset];
 			vs[k] = c;
 			offset += 1;
 		}
@@ -56,7 +56,7 @@ fn expandA_poly(reg ptr u8[32] rho, inline int i, inline int j,
 
 		if(value < Li2_q) {
 			addr = (64u) term;
-			result[(int) addr] = value;
+			result[addr] = value;
 			term += 1;
 		}
 	}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/expandMask.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/expandMask.jinc
@@ -12,8 +12,8 @@ fn expandMask_poly_shake_init(stack u64[25] state, reg ptr u8[64] rho_prime, sta
 	state = st0(state);
 	i = 0;
 	while(i < 64) {
-		c = rho_prime[(int) i];
-		state[u8 (int) i] = c;
+		c = rho_prime[i];
+		state[u8 i] = c;
 		i += 1;
 	}
 
@@ -54,9 +54,9 @@ fn expandMask_poly_gamma1_217(reg ptr u32[Li2_polydeg] f, reg ptr u8[64] rho_pri
 		i = 0;
 		while(i < SHAKE256_RATE) {
 			addr = i;
-			c = state[u8 (int) addr];
+			c = state[u8 addr];
 			addr = y_loc;
-			y_packed[(int) addr] = c;
+			y_packed[addr] = c;
 			y_loc += 1;
 			i += 1;
 		}
@@ -91,9 +91,9 @@ fn expandMask_poly_gamma1_219(reg ptr u32[Li2_polydeg] f, reg ptr u8[64] rho_pri
 		i = 0;
 		while(i < SHAKE256_RATE) {
 			addr = i;
-			c = state[u8 (int) addr];
+			c = state[u8 addr];
 			addr = y_loc;
-			y_packed[(int) addr] = c;
+			y_packed[addr] = c;
 			y_loc += 1;
 			i += 1;
 		}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/expandS.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/expandS.jinc
@@ -20,8 +20,8 @@ fn expandSEta2_poly(stack u8[64] rho_prime, reg u16 elem_idx, reg ptr u32[Li2_po
 
 	i = 0;
 	while(i < 64) {
-		c = rho_prime[(int) i];
-		state[u8 (int) i] = c;
+		c = rho_prime[i];
+		state[u8 i] = c;
 		i += 1;
 	}
 	c = (8u) elem_idx;
@@ -39,7 +39,7 @@ fn expandSEta2_poly(stack u8[64] rho_prime, reg u16 elem_idx, reg ptr u32[Li2_po
 			?{}, offset = #set0_64();
 		}
 
-		t0 = (32u)state[u8 (int) offset];
+		t0 = (32u)state[u8 offset];
 		t1 = t0;
 		offset += 1;
 
@@ -54,7 +54,7 @@ fn expandSEta2_poly(stack u8[64] rho_prime, reg u16 elem_idx, reg ptr u32[Li2_po
 			c32 = #LEA_32(4 * c32 + c32);
 			t0 -= 2;
 			c32 -= t0;
-			poly[(int) coeffs_generated] = c32;
+			poly[coeffs_generated] = c32;
 			coeffs_generated += 1;
 		}
 		if coeffs_generated < Li2_polydeg {
@@ -68,7 +68,7 @@ fn expandSEta2_poly(stack u8[64] rho_prime, reg u16 elem_idx, reg ptr u32[Li2_po
 				c32 = #LEA_32(4 * c32 + c32);
 				t0 -= 2;
 				c32 -= t0;
-				poly[(int) coeffs_generated] = c32;
+				poly[coeffs_generated] = c32;
 				coeffs_generated += 1;
 			}
 		}
@@ -98,8 +98,8 @@ fn expandSEta4_poly(stack u8[64] rho_prime, reg u16 elem_idx, reg ptr u32[Li2_po
 
 	?{}, i = #set0_64();
 	while(i < 64) {
-		c1 = rho_prime[(int) i];
-		state[u8 (int) i] = c1;
+		c1 = rho_prime[i];
+		state[u8 i] = c1;
 		i += 1;
 	}
 	c = (8u) elem_idx;
@@ -117,7 +117,7 @@ fn expandSEta4_poly(stack u8[64] rho_prime, reg u16 elem_idx, reg ptr u32[Li2_po
 			?{}, offset = #set0_64();
 		}
 
-		c = state[u8 (int) offset];
+		c = state[u8 offset];
 		offset += 1;
 
 		c32 = (32u) c;
@@ -125,7 +125,7 @@ fn expandSEta4_poly(stack u8[64] rho_prime, reg u16 elem_idx, reg ptr u32[Li2_po
 		if (c32 < 9) {
 			v = 4;
 			v -= c32;
-			poly[(int) coeffs_generated] = v;
+			poly[coeffs_generated] = v;
 			coeffs_generated += 1;
 		}
 
@@ -135,7 +135,7 @@ fn expandSEta4_poly(stack u8[64] rho_prime, reg u16 elem_idx, reg ptr u32[Li2_po
 			if(c32 < 9) {
 				v = 4;
 				v -= c32;
-				poly[(int) coeffs_generated] = v;
+				poly[coeffs_generated] = v;
 				coeffs_generated += 1;
 			}
 		}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/fips202.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/fips202.jinc
@@ -141,7 +141,7 @@ fn __keccakf1600_ref(reg ptr u64[25] state) -> reg ptr u64[25] {
     state = pi(state);
     state = chi(state);
     constptr = roundconstants;
-	  c = constptr.[(int) rctr];
+	  c = constptr.[rctr];
     state = iota(state, c);
     rctr += 8;
   }
@@ -220,8 +220,8 @@ fn shake256_squeezeblock(stack u64[25] state, stack u8[SHAKE256_RATE] out)
 
 	?{}, i = #set0_64();
 	while(i < SHAKE256_RATE) {
-		c = state[u8 (int) i];
-		out[(int) i] = c;
+		c = state[u8 i];
+		out[i] = c;
 		i += 1;
 	}
 

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/hashing_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/hashing_end.jinc
@@ -32,10 +32,10 @@ fn shake256_of_pk(reg ptr u8[Li2_PK_LEN] pk, reg ptr u8[32] out)
 		ptr_state = 0;
 		while(ptr_state < SHAKE256_RATE) {
 			addr = ptr_pk;
-			c = pk[(int) addr];
+			c = pk[addr];
 
 			addr = ptr_state;
-			state_rsp[u8 (int) addr] ^= c;
+			state_rsp[u8 addr] ^= c;
 
 			ptr_pk += 1;
 			ptr_state += 1;
@@ -46,17 +46,17 @@ fn shake256_of_pk(reg ptr u8[Li2_PK_LEN] pk, reg ptr u8[32] out)
 	ptr_state = 0;
 	while(ptr_pk < Li2_PK_LEN) {
 		addr = ptr_pk;
-		c = pk[(int) addr];
+		c = pk[addr];
 
 		addr = ptr_state;
-		state_rsp[u8 (int) addr] ^= c;
+		state_rsp[u8 addr] ^= c;
 
 		ptr_pk += 1;
 		ptr_state += 1;
 	}
 
 	addr = ptr_state;
-	state_rsp[u8 (int) addr] ^= 0x1f;
+	state_rsp[u8 addr] ^= 0x1f;
 	state_rsp[u8 SHAKE256_RATE-1] ^= 0x80;
 
 	state_rsp = __keccakf1600_ref(state_rsp);
@@ -65,8 +65,8 @@ fn shake256_of_pk(reg ptr u8[Li2_PK_LEN] pk, reg ptr u8[32] out)
 
 	addr = 0;
 	while(addr < 32) {
-		c = state_rsp[u8 (int) addr];
-		out[(int) addr] = c;
+		c = state_rsp[u8 addr];
+		out[addr] = c;
 		addr += 1;
 	}
 	return out;
@@ -105,7 +105,7 @@ fn sampleInBall(reg ptr u32[Li2_polydeg] f, reg ptr u8[32] seed)
 
 	i = 0;
 	while(i < Li2_polydeg) {
-		f[(int) i] = 0;
+		f[i] = 0;
 		i += 1;
 	}
 
@@ -117,21 +117,21 @@ fn sampleInBall(reg ptr u32[Li2_polydeg] f, reg ptr u8[32] seed)
 				state_rsp = __keccakf1600_ref(state_rsp);
 				offset = 0;
 			}
-			c = state_rsp[u8 (int) offset];
+			c = state_rsp[u8 offset];
 			b = (64u) c;
 			offset += 1;
 		} (b > i)
 
-		v32 = f[(int) b];
-		f[(int) i] = v32;
+		v32 = f[b];
+		f[i] = v32;
 
-		//f[(int) b] = 1 - 2 * (signs & 1);
+		//f[b] = 1 - 2 * (signs & 1);
 		v32 = (32u) signs;
 		v32 &= 1;
 		fb = 1;
 		fb -= v32;
 		fb -= v32;
-		f[(int) b] = fb;
+		f[b] = fb;
 
 		signs >>= 1;
 
@@ -157,8 +157,8 @@ fn hash_tr_m(reg ptr u8[32] tr, reg u64 m_len, reg u64 m)
 	state = st0(state);
 	offset = 0;
 	while(offset < 32) {
-		c = tr[(int) offset];
-		state[u8 (int) offset] ^= c;
+		c = tr[offset];
+		state[u8 offset] ^= c;
 		offset += 1;
 	}
 
@@ -168,7 +168,7 @@ fn hash_tr_m(reg ptr u8[32] tr, reg u64 m_len, reg u64 m)
 	while(space_required >= SHAKE256_RATE) {
 		while(offset < SHAKE256_RATE) {
 			c = (u8) [m + m_loc];
-			state[u8 (int) offset] ^= c;
+			state[u8 offset] ^= c;
 			m_loc += 1;
 			offset += 1;
 		}
@@ -181,19 +181,19 @@ fn hash_tr_m(reg ptr u8[32] tr, reg u64 m_len, reg u64 m)
 	//last block
 	while(m_loc < m_len) {
 		c = (u8) [m + m_loc];
-		state[u8 (int) offset] ^= c;
+		state[u8 offset] ^= c;
 		m_loc += 1;
 		offset += 1;
 	}
-	state[u8 (int) offset] ^= 0x1f;
+	state[u8 offset] ^= 0x1f;
 	state[u8 SHAKE256_RATE-1] ^= 0x80;
 
 	state = __keccakf1600_ref(state);
 
 	offset = 0;
 	while(offset < 64) {
-		c = state[u8 (int) offset];
-		mu[(int) offset] = c;
+		c = state[u8 offset];
+		mu[offset] = c;
 		offset += 1;
 	}
 	return mu;
@@ -215,8 +215,8 @@ fn hash_mu_w1(reg ptr u8[64] mu, reg ptr u8[Li2_pack_w1len] w1_packed)
 	// Absorb mu
 	while(offset < 64) {
 		state, offset = shake256_consider_permute(state, offset);
-		c = mu[(int) offset];
-		state[u8 (int) offset] ^= c;
+		c = mu[offset];
+		state[u8 offset] ^= c;
 		offset += 1;
 	}
 
@@ -224,15 +224,15 @@ fn hash_mu_w1(reg ptr u8[64] mu, reg ptr u8[Li2_pack_w1len] w1_packed)
 	?{}, w1_loc = #set0_64();
 	while(w1_loc < Li2_pack_w1len) {
 		state, offset = shake256_consider_permute(state, offset);
-		c = w1_packed[(int) w1_loc];
-		state[u8 (int) offset] ^= c;
+		c = w1_packed[w1_loc];
+		state[u8 offset] ^= c;
 		w1_loc += 1;
 		offset += 1;
 	}
 
 	// Absorb separator byte
 	state, offset = shake256_consider_permute(state, offset);
-	state[u8 (int) offset] ^= 0x1f;
+	state[u8 offset] ^= 0x1f;
 
 	// Finish
 	state, offset = shake256_consider_permute(state, offset);
@@ -241,8 +241,8 @@ fn hash_mu_w1(reg ptr u8[64] mu, reg ptr u8[Li2_pack_w1len] w1_packed)
 	?{}, offset = #set0_64();
 
 	while(offset < 32) {
-		c = state[u8 (int) offset];
-		c_tilde[(int) offset] = c;
+		c = state[u8 offset];
+		c_tilde[offset] = c;
 		offset += 1;
 	}
 	return c_tilde;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/keygen_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/keygen_end.jinc
@@ -40,18 +40,18 @@ fn keygen_inner(reg ptr u8[32] random_zeta)
 	//TODO Maybe can load 8 bytes at a time using u64?
 	i = 0;
 	while(i < 32) {
-		c = s256_out[(int) i];
-		rho[(int) i] = c;
+		c = s256_out[i];
+		rho[i] = c;
 		i += 1;
 	}
 	while(i < 96) {
-		c = s256_out[(int) i];
-		rho_prime[(int) (i - 32)] = c;
+		c = s256_out[i];
+		rho_prime[i - 32] = c;
 		i += 1;
 	}
 	while(i < 128) {
-		c = s256_out[(int) i];
-		k[(int) (i - 96)] = c;
+		c = s256_out[i];
+		k[i - 96] = c;
 		i += 1;
 	}
 
@@ -127,7 +127,7 @@ fn keygen(reg u64 pk_ptr sk_ptr)
   pk_ptr = pk_ptr_s;
 	i = 0;
 	while(i < Li2_PK_LEN) {
-		c = pk[(int) i];
+		c = pk[i];
 		(u8)[pk_ptr + i] = c;
 		i += 1;
 	}
@@ -135,7 +135,7 @@ fn keygen(reg u64 pk_ptr sk_ptr)
   sk_ptr = sk_ptr_s;
 	i = 0;
 	while(i < Li2_SK_LEN) {
-		c = sk[(int) i];
+		c = sk[i];
 		(u8)[sk_ptr + i] = c;
 		i += 1;
 	}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/ntt.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/ntt.jinc
@@ -37,7 +37,7 @@ fn fft(reg ptr u32[Li2_polydeg] f) -> reg ptr u32[Li2_polydeg]
 			//zeta = zetas[k++];
 			tfs = twiddle_factors;
 			addr = (64u) k;
-			v32 = tfs[(int) addr];
+			v32 = tfs[addr];
 			zeta = v32;
 			k += 1;
 
@@ -47,10 +47,10 @@ fn fft(reg ptr u32[Li2_polydeg] f) -> reg ptr u32[Li2_polydeg]
 			bound += len;
 			while {
 				addr = (64u) j;
-				v32 = f[(int) addr];
+				v32 = f[addr];
 				left = v32;
 				addr += len;
-				v32 = f[(int) addr];
+				v32 = f[addr];
 				right = v32;
 
 				//t = montgomery_reduce((int64_t)zeta * a[j + len]);
@@ -71,10 +71,10 @@ fn fft(reg ptr u32[Li2_polydeg] f) -> reg ptr u32[Li2_polydeg]
 				
 				addr = (64u) j;
 				v32 = left;
-				f[(int) addr] = v32;
+				f[addr] = v32;
 				addr += len;
 				v32 = right;
-				f[(int) addr] = v32;
+				f[addr] = v32;
 
 				j += 1;
 				rbound = bound;
@@ -119,7 +119,7 @@ fn ifft_to_mont(reg ptr u32[Li2_polydeg] f) -> reg ptr u32[Li2_polydeg]
 
 			tfs = twiddle_factors;
 			addr = (64u) k;
-			v32 = tfs[(int) addr];
+			v32 = tfs[addr];
 			v32 *= -1;
 			zeta = v32;
 
@@ -128,10 +128,10 @@ fn ifft_to_mont(reg ptr u32[Li2_polydeg] f) -> reg ptr u32[Li2_polydeg]
 			bound += len;
 			while {
 				addr = (64u) j;
-				v32 = f[(int) addr];
+				v32 = f[addr];
 				left = v32;
 				addr += len;
-				v32 = f[(int) addr];
+				v32 = f[addr];
 				right = v32;
 				
 				// t = a[j];
@@ -157,10 +157,10 @@ fn ifft_to_mont(reg ptr u32[Li2_polydeg] f) -> reg ptr u32[Li2_polydeg]
 	
 				addr = (64u) j;
 				v32 = left;
-				f[(int) addr] = v32;
+				f[addr] = v32;
 				addr += len;
 				v32 = right;
-				f[(int) addr] = v32;
+				f[addr] = v32;
 
 				j += 1;
 				rbound = bound;
@@ -176,13 +176,13 @@ fn ifft_to_mont(reg ptr u32[Li2_polydeg] f) -> reg ptr u32[Li2_polydeg]
 	while(j < Li2_polydeg) {
 		//a[j] = montgomery_reduce((int64_t)f * a[j]);
 		addr = (64u) j;
-		v32 = f[(int) addr];
+		v32 = f[addr];
 
 		v64 = (64s) v32;
 		v64 *= mont_sq_over_256;
 		v32 = montgomery_REDC(v64);
 
-		f[(int) addr] = v32;
+		f[addr] = v32;
 		j += 1;
 	}
 	

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/packing.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/packing.jinc
@@ -30,7 +30,7 @@ fn polyeta_2_pack(reg ptr u32[Li2_polydeg] s1, reg ptr u8[Li2_pack_eta_2_len] de
 
         // r[3*i+0]  = (t[0] >> 0) | (t[1] << 3) | (t[2] << 6);
 		dest0 = _eta; // t0
-		dest0 -= s1[(int) i];
+		dest0 -= s1[i];
 		t1 = _eta;
 		t1 -= s1[(int) i + 1];
 		t1 <<= 3;
@@ -89,7 +89,7 @@ fn polyeta_4_pack(reg ptr u32[Li2_polydeg] s1, reg ptr u8[Li2_pack_eta_4_len] de
 	_eta = 4;
 	?{}, i = #set0_64();
 	while (i < Li2_polydeg) {
-		coeff = s1[(int) i];
+		coeff = s1[i];
 		lo = _eta;
 		lo -= coeff;
 
@@ -102,7 +102,7 @@ fn polyeta_4_pack(reg ptr u32[Li2_polydeg] s1, reg ptr u8[Li2_pack_eta_4_len] de
 
 		addr = i;
 		addr >>= 1;
-		dest[(int) addr] = hi;
+		dest[addr] = hi;
 
 		i += 2;
 	}
@@ -133,7 +133,7 @@ fn polyeta_2_unpack(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_eta_2_len] a
 		c32_0 &= 0x7;
 		coeff = _eta;
 		coeff -= c32_0;
-		r[(int) dest_addr] = coeff;
+		r[dest_addr] = coeff;
 		// r->coeffs[8*i+1] =  (a[3*i+0] >> 3) & 7;
 		c32_0 = a0;
 		c32_0 >>= 3;
@@ -208,7 +208,7 @@ fn polyeta_4_unpack(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_eta_4_len] a
 	?{}, i = #set0_64();
 	while (i < Li2_polydeg / 2) {
 		// r->coeffs[2*i+0] = a[i] & 0x0F;
-		x = (32u) a[(int) i];
+		x = (32u) a[i];
 		x &= 0x0F;
 		// r->coeffs[2*i+0] = ETA - r->coeffs[2*i+0];
 		x = -x;
@@ -216,7 +216,7 @@ fn polyeta_4_unpack(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_eta_4_len] a
 		r[2 * ((int) i)] = x;
 
 	    // r->coeffs[2*i+1] = a[i] >> 4;
-		x = (32u) a[(int) i];
+		x = (32u) a[i];
 		x >>= 4;
 		// r->coeffs[2*i+1] = ETA - r->coeffs[2*i+1];
 		x = -x;
@@ -334,7 +334,7 @@ fn polyz_unpack_gamma1_217(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		// r->coeffs[4*i+0] = GAMMA1 - r->coeffs[4*i+0];
 		x -= 1 << 17;
 		x = -x;
-		r[(int) (out_addr + 0)] = x;
+		r[out_addr + 0] = x;
 
 		// r->coeffs[4*i+1]  = a[9*i+2] >> 2;
 		x = (32u) a[(int) in_addr + 2];
@@ -356,7 +356,7 @@ fn polyz_unpack_gamma1_217(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		// r->coeffs[4*i+1] = GAMMA1 - r->coeffs[4*i+1];
 		x -= 1 << 17;
 		x = -x;
-		r[(int) (out_addr + 1)] = x;
+		r[out_addr + 1] = x;
 
 		// r->coeffs[4*i+2]  = a[9*i+4] >> 4;
 		x = (32u) a[(int) in_addr + 4];
@@ -378,7 +378,7 @@ fn polyz_unpack_gamma1_217(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		// r->coeffs[4*i+2] = GAMMA1 - r->coeffs[4*i+2];
 		x -= 1 << 17;
 		x = -x;
-		r[(int) (out_addr + 2)] = x;
+		r[out_addr + 2] = x;
 
 		// r->coeffs[4*i+3]  = a[9*i+6] >> 6;
 		x = (32u) a[(int) in_addr + 6];
@@ -400,7 +400,7 @@ fn polyz_unpack_gamma1_217(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		// r->coeffs[4*i+3] = GAMMA1 - r->coeffs[4*i+3];
 		x -= 1 << 17;
 		x = -x;
-		r[(int) (out_addr + 3)] = x;
+		r[out_addr + 3] = x;
 
 		i += 1;
 	}
@@ -434,7 +434,7 @@ fn polyz_pack_gamma1_219(reg ptr u8[Li2_pack_zlen_gamma1_219] r, reg ptr u32[Li2
 
 		// r[5*i+0]  = t[0];
 		x = t0;
-		r[(int) dest_addr] = (8u) x;
+		r[dest_addr] = (8u) x;
 
 		// r[5*i+1]  = t[0] >> 8;
 		x = t0;
@@ -483,13 +483,13 @@ fn polyz_unpack_gamma1_219(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		addr *= 5;
 
 		//r->coeffs[2*i+0]  = a[5*i+0];
-		x = (32u) a[(int) addr];
+		x = (32u) a[addr];
 
 		//r->coeffs[2*i+0] |= (uint32_t)a[5*i+1] << 8;
 		addr = i;
 		addr *= 5;
 		addr += 1;
-		c32 = (32u) a[(int) addr];
+		c32 = (32u) a[addr];
 		c32 <<= 8;
 		x |= c32;
 		
@@ -497,7 +497,7 @@ fn polyz_unpack_gamma1_219(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		addr = i;
 		addr *= 5;
 		addr += 2;
-		c32 = (32u) a[(int) addr];
+		c32 = (32u) a[addr];
 		c32 <<= 16;
 		x |= c32;
 
@@ -508,20 +508,20 @@ fn polyz_unpack_gamma1_219(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		x += 1 << 19;
 		addr = i;
 		addr *= 2;
-		r[(int) addr] = x;
+		r[addr] = x;
 
 		//r->coeffs[2*i+1]  = a[5*i+2] >> 4;
 		addr = i;
 		addr *= 5;
 		addr += 2;
-		x = (32u) a[(int) addr];
+		x = (32u) a[addr];
 		x >>= 4;
 
 		//r->coeffs[2*i+1] |= (uint32_t)a[5*i+3] << 4;
 		addr = i;
 		addr *= 5;
 		addr += 3;
-		c32 = (32u) a[(int) addr];
+		c32 = (32u) a[addr];
 		c32 <<= 4;
 		x |= c32;
 
@@ -529,7 +529,7 @@ fn polyz_unpack_gamma1_219(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		addr = i;
 		addr *= 5;
 		addr += 4;
-		c32 = (32u) a[(int) addr];
+		c32 = (32u) a[addr];
 		c32 <<= 12;
 		x |= c32;
 
@@ -539,7 +539,7 @@ fn polyz_unpack_gamma1_219(reg ptr u32[Li2_polydeg] r, reg ptr u8[Li2_pack_zlen_
 		addr = i;
 		addr *= 2;
 		addr += 1;
-		r[(int) addr] = x;
+		r[addr] = x;
 
 		i += 1;
 	}
@@ -560,24 +560,24 @@ fn polyt1_pack(reg ptr u32[Li2_polydeg] t1, reg ptr u8[Li2_pack_t1len] buf)
 
 		addr = 4;
 		addr *= i;
-		x = t1[(int) addr];
+		x = t1[addr];
 		c = (8u) x;
 
 		addr = 5;
 		addr *= i;
-		buf[(int) addr] = c;
+		buf[addr] = c;
 
 		// buf[5*i+1] = (t1[4*i+0] >> 8) | (t1[4*i+1] << 2);
 
 		addr = 4;
 		addr *= i;
-		x = t1[(int) addr];
+		x = t1[addr];
 		x >>= 8;
 
 		addr = 4;
 		addr *= i;
 		addr += 1;
-		x1 = t1[(int) addr];
+		x1 = t1[addr];
 		x1 <<= 2;
 		x |= x1;
 
@@ -585,20 +585,20 @@ fn polyt1_pack(reg ptr u32[Li2_polydeg] t1, reg ptr u8[Li2_pack_t1len] buf)
 		addr *= i;
 		addr += 1;
 		c = (8u) x;
-		buf[(int) addr] = c;
+		buf[addr] = c;
 
 		// buf[5*i+2] = (t1[4*i+1] >> 6) | (t1[4*i+2] << 4);
 
 		addr = 4;
 		addr *= i;
 		addr += 1;
-		x = t1[(int) addr];
+		x = t1[addr];
 		x >>= 6;
 
 		addr = 4;
 		addr *= i;
 		addr += 2;
-		x1 = t1[(int) addr];
+		x1 = t1[addr];
 		x1 <<= 4;
 		x |= x1;
 
@@ -606,20 +606,20 @@ fn polyt1_pack(reg ptr u32[Li2_polydeg] t1, reg ptr u8[Li2_pack_t1len] buf)
 		addr *= i;
 		addr += 2;
 		c = (8u) x;
-		buf[(int) addr] = c;
+		buf[addr] = c;
 
 		// buf[5*i+3] = (t1[4*i+2] >> 4) | (t1[4*i+3] << 6);
 
 		addr = 4;
 		addr *= i;
 		addr += 2;
-		x = t1[(int) addr];
+		x = t1[addr];
 		x >>= 4;
 
 		addr = 4;
 		addr *= i;
 		addr += 3;
-		x1 = t1[(int) addr];
+		x1 = t1[addr];
 		x1 <<= 6;
 		x |= x1;
 
@@ -627,21 +627,21 @@ fn polyt1_pack(reg ptr u32[Li2_polydeg] t1, reg ptr u8[Li2_pack_t1len] buf)
 		addr *= i;
 		addr += 3;
 		c = (8u) x;
-		buf[(int) addr] = c;
+		buf[addr] = c;
 
 		// buf[5*i+4] = (t1[4*i+3] >> 2);
 
 		addr = 4;
 		addr *= i;
 		addr += 3;
-		x = t1[(int) addr];
+		x = t1[addr];
 		x >>= 2;
 
 		addr = 5;
 		addr *= i;
 		addr += 4;
 		c = (8u) x;
-		buf[(int) addr] = c;
+		buf[addr] = c;
 
 		i += 1;
 	}
@@ -721,11 +721,11 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		?{}, j = #set0_64();
 		while (j < 8) {
 			addr = #LEA_64(8*i + j);
-			v32 = t0[(int) addr];
+			v32 = t0[addr];
 			t0_term = v32;
 			v32 = max_t0;
 			v32 -= t0_term;
-			t[(int) j] = v32;
+			t[j] = v32;
 			j += 1;
 		}
 
@@ -739,7 +739,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		c = (8u) v32;
 		addr = i;
 		addr *= 13;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 1]  =  t[0] >>  8;
 		//r[13*i+ 1] |=  t[1] <<  5;
@@ -754,7 +754,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 1;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 2]  =  t[1] >>  3;
 
@@ -764,7 +764,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 2;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 3]  =  t[1] >> 11;
 		//r[13*i+ 3] |=  t[2] <<  2;
@@ -779,7 +779,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 3;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 4]  =  t[2] >>  6;
 		//r[13*i+ 4] |=  t[3] <<  7;
@@ -794,7 +794,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 4;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 5]  =  t[3] >>  1;
 
@@ -804,7 +804,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 5;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 6]  =  t[3] >>  9;
 		//r[13*i+ 6] |=  t[4] <<  4;
@@ -819,7 +819,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 6;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 7]  =  t[4] >>  4;
 
@@ -829,7 +829,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 7;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 8]  =  t[4] >> 12;
 		//r[13*i+ 8] |=  t[5] <<  1;
@@ -844,7 +844,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 8;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+ 9]  =  t[5] >>  7;
 		//r[13*i+ 9] |=  t[6] <<  6;
@@ -859,7 +859,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 9;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+10]  =  t[6] >>  2;
 
@@ -869,7 +869,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 10;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+11]  =  t[6] >> 10;
 		//r[13*i+11] |=  t[7] <<  3;
@@ -884,7 +884,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 11;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		//r[13*i+12]  =  t[7] >>  5;
 
@@ -894,7 +894,7 @@ fn polyt0_pack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] dest)
 		addr = i;
 		addr *= 13;
 		addr += 12;
-		dest[(int) addr] = c;
+		dest[addr] = c;
 
 		i += 1;
 	}
@@ -922,11 +922,11 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		// r->coeffs[8*i+0] = a[13*i+0];
 		addr = (64u) i;
 		addr *= 13;
-		x = (32u) src[(int) addr];
+		x = (32u) src[addr];
 
 		// r->coeffs[8*i+0] |= (uint32_t)a[13*i+1] << 8;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 8;
 		x |= v;
 
@@ -938,21 +938,21 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		x += max_t0;
 		term = (64u) i;
 		term *= 8;
-		t0[(int) term] = x;
+		t0[term] = x;
 
 		// r->coeffs[8*i+1]  = a[13*i+1] >> 5;
-		x = (32u) src[(int) addr];
+		x = (32u) src[addr];
 		x >>= 5;
 		
 		// r->coeffs[8*i+1] |= (uint32_t)a[13*i+2] << 3;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 3;
 		x |= v;
 
 		// r->coeffs[8*i+1] |= (uint32_t)a[13*i+3] << 11;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 11;
 		x |= v;
 
@@ -963,15 +963,15 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		x = -x;
 		x += max_t0;
 		term += 1;
-		t0[(int) term] = x;
+		t0[term] = x;
 
 		// r->coeffs[8*i+2]  = a[13*i+3] >> 2;
-		x = (32u) src[(int) addr];
+		x = (32u) src[addr];
 		x >>= 2;
 
 		// r->coeffs[8*i+2] |= (uint32_t)a[13*i+4] << 6;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 6;
 		x |= v;
 		
@@ -982,21 +982,21 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		x = -x;
 		x += max_t0;
 		term += 1;
-		t0[(int) term] = x;
+		t0[term] = x;
 
 		// r->coeffs[8*i+3]  = a[13*i+4] >> 7;
-		x = (32u) src[(int) addr];
+		x = (32u) src[addr];
 		x >>= 7;
 
 		// r->coeffs[8*i+3] |= (uint32_t)a[13*i+5] << 1;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 1;
 		x |= v;
 
 		// r->coeffs[8*i+3] |= (uint32_t)a[13*i+6] << 9;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 9;
 		x |= v;
 
@@ -1007,21 +1007,21 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		x = -x;
 		x += max_t0;
 		term += 1;
-		t0[(int) term] = x;
+		t0[term] = x;
 
 		// r->coeffs[8*i+4]  = a[13*i+6] >> 4;
-		x = (32u) src[(int) addr];
+		x = (32u) src[addr];
 		x >>= 4;
 
 		// r->coeffs[8*i+4] |= (uint32_t)a[13*i+7] << 4;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 4;
 		x |= v;
 
 		// r->coeffs[8*i+4] |= (uint32_t)a[13*i+8] << 12;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 12;
 		x |= v;
 
@@ -1032,15 +1032,15 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		x = -x;
 		x += max_t0;
 		term += 1;
-		t0[(int) term] = x;
+		t0[term] = x;
 
 		// r->coeffs[8*i+5]  = a[13*i+8] >> 1;
-		x = (32u) src[(int) addr];
+		x = (32u) src[addr];
 		x >>= 1;
 
 		// r->coeffs[8*i+5] |= (uint32_t)a[13*i+9] << 7;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 7;
 		x |= v;
 
@@ -1051,21 +1051,21 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		x = -x;
 		x += max_t0;
 		term += 1;
-		t0[(int) term] = x;
+		t0[term] = x;
 
 		// r->coeffs[8*i+6]  = a[13*i+9] >> 6;
-		x = (32u) src[(int) addr];
+		x = (32u) src[addr];
 		x >>= 6;
 		
 		// r->coeffs[8*i+6] |= (uint32_t)a[13*i+10] << 2;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 2;
 		x |= v;
 
 		// r->coeffs[8*i+6] |= (uint32_t)a[13*i+11] << 10;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 10;
 		x |= v;
 
@@ -1076,15 +1076,15 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		x = -x;
 		x += max_t0;
 		term += 1;
-		t0[(int) term] = x;
+		t0[term] = x;
 
 		// r->coeffs[8*i+7]  = a[13*i+11] >> 3;
-		x = (32u) src[(int) addr];
+		x = (32u) src[addr];
 		x >>= 3;
 
 		// r->coeffs[8*i+7] |= (uint32_t)a[13*i+12] << 5;
 		addr += 1;
-		v = (32u) src[(int) addr];
+		v = (32u) src[addr];
 		v <<= 5;
 		x |= v;
 
@@ -1095,7 +1095,7 @@ fn polyt0_unpack(reg ptr u32[Li2_polydeg] t0, reg ptr u8[Li2_pack_t0len] src)
 		x = -x;
 		x += max_t0;
 		term += 1;
-		t0[(int) term] = x;
+		t0[term] = x;
 
 		i += 1;
 	}
@@ -1159,7 +1159,7 @@ fn polyw1_pack_gamma2_32(reg ptr u32[Li2_polydeg] w1, reg ptr u8[Li2_pack_highbi
 		c32 = w1[(int) src_addr + 1];
 		c32 <<= 4;
 		c32 |= w1[(int) src_addr + 0];
-		w1_buf[(int) i] = (8u) c32;
+		w1_buf[i] = (8u) c32;
 
 		i += 1;
 		src_addr += 2;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/packing_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/packing_end.jinc
@@ -73,8 +73,8 @@ fn pack_signature(reg ptr u8[32] c_tilde,
 
 	?{}, i = #set0_64();
 	while (i < 32) {
-		c = c_tilde[(int) i];
-		signature[(int) i] = c;
+		c = c_tilde[i];
+		signature[i] = c;
 		i += 1;
 	}
 
@@ -88,7 +88,7 @@ fn pack_signature(reg ptr u8[32] c_tilde,
 	// Clear the hints buffer
 	?{}, i = #set0_64();
 	while (i < Li2_omega + Li2_k) {
-		signature[(int) (Li2_pack_hstart + i)] = 0;
+		signature[Li2_pack_hstart + i] = 0;
 		i += 1;
 	}
 
@@ -101,14 +101,14 @@ fn pack_signature(reg ptr u8[32] c_tilde,
 			addr = i;
 			addr <<= Li2_log2polydeg;
 			addr += j;
-			coeff = h[(int) addr];
+			coeff = h[addr];
 			if coeff != 0 {
-				signature[(int) (Li2_pack_hstart + k)] = (8u) j;
+				signature[Li2_pack_hstart + k] = (8u) j;
 				k += 1;
 			}
 			j += 1;
 		}
-		signature[(int) (Li2_pack_hstart + Li2_omega + i)] = (8u) k;
+		signature[Li2_pack_hstart + Li2_omega + i] = (8u) k;
 		i += 1;
 	}
 

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/poly.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/poly.jinc
@@ -9,10 +9,10 @@ fn poly_add(reg ptr u32[Li2_polydeg] f g sum)
 	reg u64 i;
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		result = f[(int) i];
-		v32 = g[(int) i];
+		result = f[i];
+		v32 = g[i];
 		result += v32;
-		sum[(int) i] = result;
+		sum[i] = result;
 		i += 1;
 	}
 	return sum;
@@ -26,10 +26,10 @@ fn poly_subtract(reg ptr u32[Li2_polydeg] f g difference)
 	reg u64 i;
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		result = f[(int) i];
-		v32 = g[(int) i];
+		result = f[i];
+		v32 = g[i];
 		result -= v32;
-		difference[(int) i] = result;
+		difference[i] = result;
 		i += 1;
 	}
 	return difference;
@@ -43,10 +43,10 @@ fn poly_accumulate(reg ptr u32[Li2_polydeg] f sum)
 	reg u64 i;
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		v32 = f[(int) i];
-		result = sum[(int) i];
+		v32 = f[i];
+		result = sum[i];
 		result += v32;
-		sum[(int) i] = result;
+		sum[i] = result;
 		i += 1;
 	}
 	return sum;
@@ -60,9 +60,9 @@ fn poly_reduce32(reg ptr u32[Li2_polydeg] poly)
 
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		val = poly[(int) i];
+		val = poly[i];
 		res = reduce32(val);
-		poly[(int) i] = res;
+		poly[i] = res;
 		i += 1;
 	}
 
@@ -79,14 +79,14 @@ fn poly_pointwise_montgomery(reg ptr u32[Li2_polydeg] fft_f fft_g fft_prod)
 
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		x1 = fft_f[(int) i];
+		x1 = fft_f[i];
 		prod = (64s) x1;
-		x2 = fft_g[(int) i];
+		x2 = fft_g[i];
 		x2_64 = (64s) x2;
 		prod *= x2_64;
 		
 		prod_redc = montgomery_REDC(prod);
-		fft_prod[(int) i] = prod_redc;
+		fft_prod[i] = prod_redc;
 		i += 1;
 	}
 	return fft_prod;
@@ -99,7 +99,7 @@ fn zero_poly(reg ptr u32[Li2_polydeg] f)
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
 		// Montgomery of 0 is 0
-		f[(int) i] = 0;
+		f[i] = 0;
 		i += 1;
 	}
 	return f;
@@ -112,9 +112,9 @@ fn poly_caddq(reg ptr u32[Li2_polydeg] f)
 	reg u32 val;
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		val = f[(int) i];
+		val = f[i];
 		val = caddq(val);
-		f[(int) i] = val;
+		f[i] = val;
 		i += 1;
 	}
 	return f;
@@ -135,7 +135,7 @@ fn poly_checknorm(reg ptr u32[Li2_polydeg] f, inline int threshold)
 
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		val = f[(int) i];
+		val = f[i];
 		r = checknorm(val, threshold);
 		c = r;
 		result |= c;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/poly_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/poly_end.jinc
@@ -11,17 +11,17 @@ fn poly_make_hint(reg ptr u32[Li2_polydeg] f0 f1 hints)
 
 	i = 0;
 	while(i < Li2_polydeg) {
-		hints[(int) i] = 0;
+		hints[i] = 0;
 		i += 1;
 	}
 
 	weight = 0;
 	i = 0;
 	while(i < Li2_polydeg) {
-		a0 = f0[(int) i];
-		a1 = f1[(int) i];
+		a0 = f0[i];
+		a1 = f1[i];
 		h = make_hint(a0, a1);
-		hints[(int) i] = h;
+		hints[i] = h;
 		weight += h;
 		i += 1;
 	}
@@ -37,10 +37,10 @@ fn poly_use_hint(reg ptr u32[Li2_polydeg] w1 hints)
 
 	i = 0;
 	while (i < Li2_polydeg) {
-		h = hints[(int) i];
-		a = w1[(int) i];
+		h = hints[i];
+		a = w1[i];
 		a = use_hint(a, h);
-		w1[(int) i] = a;
+		w1[i] = a;
 		i += 1;
 	}
 	return w1;

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/polyvec_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/polyvec_end.jinc
@@ -9,9 +9,9 @@ fn reduce32_vecl(reg ptr u32[Li2_l * Li2_polydeg] vec)
 
 	?{}, i = #set0_64();
 	while(i < Li2_l * Li2_polydeg) {
-		val = vec[(int) i];
+		val = vec[i];
 		res = reduce32(val);
-		vec[(int) i] = res;
+		vec[i] = res;
 		i += 1;
 	}
 
@@ -26,9 +26,9 @@ fn reduce32_veck(reg ptr u32[Li2_k * Li2_polydeg] vec)
 
 	?{}, i = #set0_64();
 	while(i < Li2_k * Li2_polydeg) {
-		val = vec[(int) i];
+		val = vec[i];
 		res = reduce32(val);
-		vec[(int) i] = res;
+		vec[i] = res;
 		i += 1;
 	}
 
@@ -107,10 +107,10 @@ fn power2round_vec(reg ptr u32[Li2_k * Li2_polydeg] v)
 
 	?{}, i = #set0_64();
 	while(i < Li2_k * Li2_polydeg) {
-		x = v[(int) i];
+		x = v[i];
 		y1, y2 = power2round(x);
-		t1[(int) i] = y1;
-		t0[(int) i] = y2;
+		t1[i] = y1;
+		t0[i] = y2;
 		i += 1;
 	}
 
@@ -245,13 +245,13 @@ fn pointwise_mont_mult(reg ptr u32[Li2_polydeg] f g fg)
 	reg u32 prod_redc;
 	?{}, i = #set0_64();
 	while(i < Li2_polydeg) {
-		v32 = f[(int) i];
+		v32 = f[i];
 		result = (64s) v32;
-		v32 = g[(int) i];
+		v32 = g[i];
 		gv_64 = (64s) v32;
 		result *= gv_64;
 		prod_redc = montgomery_REDC(result);
-		fg[(int) i] = prod_redc;
+		fg[i] = prod_redc;
 		i += 1;
 	}
 	return fg;
@@ -268,8 +268,8 @@ fn deep_copy_vecl(reg ptr u32[Li2_l * Li2_polydeg] vec)
 
 	?{}, i = #set0_64();
 	while(i < Li2_l * Li2_polydeg) {
-		entry = vec[(int) i];
-		dest[(int) i] = entry;
+		entry = vec[i];
+		dest[i] = entry;
 		i += 1;
 	}
 	return dest;
@@ -287,13 +287,13 @@ fn decompose_vec(reg ptr u32[Li2_k * Li2_polydeg] vec)
 	?{}, i = #set0_64();
 	while(i < Li2_k * Li2_polydeg) {
 		addr = i;
-		a = vec[(int) addr];
+		a = vec[addr];
 
 		a0, a1 = decompose(a);
 
 		addr = i;
-		vec0[(int) addr] = a0;
-		vec1[(int) addr] = a1;
+		vec0[addr] = a0;
+		vec1[addr] = a1;
 
 		i += 1;
 	}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/sign.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/sign.jinc
@@ -21,7 +21,7 @@ inline fn __sign(reg u64 sm smlen_p m mlen sk) -> reg u64
   ?{}, i = #set0();
   while(i < Li2_SK_LEN) {
     c = (u8)[sk + i];
-    secret_key[(int) i] = c;
+    secret_key[i] = c;
     i += 1;
   } // sk dead.
 
@@ -49,7 +49,7 @@ inline fn __sign(reg u64 sm smlen_p m mlen sk) -> reg u64
   sm = s_sm;
   ?{}, i = #set0();
   while(i < Li2_SIGN_LEN)
-  { c = signature[(int) i];
+  { c = signature[i];
     (u8)[sm + i] = c;
     i += 1;
   }

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/sign_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/sign_end.jinc
@@ -21,15 +21,15 @@ fn compute_rho_prime(reg ptr u8[32] k, reg ptr u8[64] mu)
 	state = st0(state);
 	?{}, i = #set0_64();
 	while(i < 32) {
-		c = k[(int) i];
-		state[u8 (int) i] = c;	
+		c = k[i];
+		state[u8 i] = c;	
 		i += 1;
 	}
 	while(i < 96) {
 		mu_loc = i;
 		mu_loc -= 32;
-		c = mu[(int) mu_loc];
-		state[u8 (int) i] = c;
+		c = mu[mu_loc];
+		state[u8 i] = c;
 		i += 1;
 	}
 
@@ -40,8 +40,8 @@ fn compute_rho_prime(reg ptr u8[32] k, reg ptr u8[64] mu)
 
 	?{}, i = #set0_64();
 	while(i < 64) {
-		c = state[u8 (int) i];
-		rho_prime[(int) i] = c;
+		c = state[u8 i];
+		rho_prime[i] = c;
 		i += 1;
 	}
 	return rho_prime;
@@ -216,7 +216,7 @@ fn sign(reg u64 ptr_signature, reg u64 ptr_m, reg u64 m_len, reg u64 ptr_sk) -> 
 	?{}, i = #set0_64();
 	while(i < Li2_SK_LEN) {
 		c = (u8)[ptr_sk + i];
-		sk[(int) i] = c;
+		sk[i] = c;
 		i += 1;
 	}
 	
@@ -226,7 +226,7 @@ fn sign(reg u64 ptr_signature, reg u64 ptr_m, reg u64 m_len, reg u64 ptr_sk) -> 
 	
 	?{}, i = #set0_64();
 	while(i < Li2_SIGN_LEN) {
-		c = signature[(int) i];
+		c = signature[i];
 		(u8) [sig_addr + i] = c;
 		i += 1;
 	}

--- a/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/verify_end.jinc
+++ b/oldsrc-should-delete/crypto_sign/dilithium/common/amd64/verify_end.jinc
@@ -5,9 +5,9 @@ fn poly_shiftl(reg ptr u32[Li2_polydeg] f) -> reg ptr u32[Li2_polydeg] {
 
     ?{}, i = #set0_64();
     while (i < Li2_polydeg) {
-        coeff = f[(int) i];
+        coeff = f[i];
         coeff <<= Li2_d;
-        f[(int) i] = coeff;
+        f[i] = coeff;
         i += 1;
     }
 
@@ -42,12 +42,12 @@ fn unpack_hints(reg ptr u8[Li2_omega + Li2_k] hints_buf, reg ptr u32[Li2_k * Li2
         ?{}, zero = #set0_32();
         while (j < Li2_polydeg) {
             idx = #LEA_64(hints_elem_offset + j);
-            hints[(int) idx] = zero;
+            hints[idx] = zero;
             j += 1;
         }
 
         // if (sig[OMEGA + i] < k || sig[OMEGA + i] > OMEGA) { return 1; }
-        hints_cumpop = (64u)hints_buf[(int) (Li2_omega + i)];
+        hints_cumpop = (64u)hints_buf[Li2_omega + i];
         if (hints_cumpop < k) {
             fail = 1;
         } else {
@@ -62,7 +62,7 @@ fn unpack_hints(reg ptr u8[Li2_omega + Li2_k] hints_buf, reg ptr u32[Li2_k * Li2
                 } (done == 0) {
                     // Coefficients are ordered for strong unforgeability
                     // if(j > k && sig[j] <= sig[j-1]) return 1;
-                    idx1 = (64u)hints_buf[(int) j];
+                    idx1 = (64u)hints_buf[j];
                     if (j > k) {
                         idx2 = (64u)hints_buf[(int) j-1];
                         if (idx1 <= idx2) {
@@ -72,7 +72,7 @@ fn unpack_hints(reg ptr u8[Li2_omega + Li2_k] hints_buf, reg ptr u32[Li2_k * Li2
                     if (fail == 0) {
                         // h->vec[i].coeffs[sig[j]] = 1;
                         idxtmp = #LEA_64(hints_elem_offset + idx1);
-                        hints[(int) idxtmp] = 1;
+                        hints[idxtmp] = 1;
 
                         j += 1;
 
@@ -101,8 +101,8 @@ fn cmp_ctilde(stack u8[32] c_tilde1 c_tilde2) -> reg u8 {
     ?{}, result = #set0_8();
     ?{}, i = #set0_64();
     while (i < 32) {
-        b1 = c_tilde1[(int) i];
-        b2 = c_tilde2[(int) i];
+        b1 = c_tilde1[i];
+        b2 = c_tilde2[i];
         if (b1 != b2) {
             result |= 0xFF;
         }
@@ -186,8 +186,8 @@ fn verify_inner(stack ptr u8[Li2_SIGN_LEN] sig, reg u64 m, reg u64 m_len, stack 
             sig_rsp = sig;
             ?{}, i = #set0_64();
             while (i < 32) {
-                byte = sig_rsp[(int) i];
-                c_tilde[(int) i] = byte;
+                byte = sig_rsp[i];
+                c_tilde[i] = byte;
                 i += 1;
             }
             challenge = sampleInBall(challenge, c_tilde);
@@ -240,14 +240,14 @@ fn verify(reg u64 ptr_sig, reg u64 ptr_m, reg u64 m_len, reg u64 ptr_pk) -> reg 
     ?{}, i = #set0_64();
 	while(i < Li2_PK_LEN) {
 		byte = (u8)[ptr_pk + i];
-		pk_rsp[(int) i] = byte;
+		pk_rsp[i] = byte;
 		i += 1;
 	}
 
     ?{}, i = #set0_64();
     while(i < Li2_SIGN_LEN) {
 		byte = (u8)[ptr_sig + i];
-		sig_rsp[(int) i] = byte;
+		sig_rsp[i] = byte;
 		i += 1;
 	}
 

--- a/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/NTT.jinc
+++ b/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/NTT.jinc
@@ -327,8 +327,8 @@ fn __basemul(stack u16[ARRAY_N] des src1 src2) -> stack u16[ARRAY_N] {
     i = 0;
     while(i < ARRAY_N * 2){
 
-        a = src1.[u256 (int) i];
-        b = src2.[u256 (int) i];
+        a = src1.[u256 i];
+        b = src2.[u256 i];
 
         lo = #VPMULL_16u16(a, b);
         hi = #VPMULH_16u16(a, b);
@@ -337,7 +337,7 @@ fn __basemul(stack u16[ARRAY_N] des src1 src2) -> stack u16[ARRAY_N] {
         lo = #VPMULH_16u16(lo, __q);
         c = #VPSUB_16u16(hi, lo);
 
-        des.[u256 (int) i] = c;
+        des.[u256 i] = c;
 
         i += 32;
 

--- a/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/sign.jinc
+++ b/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/sign.jinc
@@ -148,9 +148,9 @@ inline fn __hash_to_point_vartime(stack u64[25] state, stack u16[ARRAY_N] hm) ->
 
         } else if(t < SHAKE256_RATE - 1){
 
-            buff[1] = block_buff[(int) t];
+            buff[1] = block_buff[t];
             t += 1;
-            buff[0] = block_buff[(int) t];
+            buff[0] = block_buff[t];
             t += 1;
             s_indx = t;
 
@@ -164,7 +164,7 @@ inline fn __hash_to_point_vartime(stack u64[25] state, stack u16[ARRAY_N] hm) ->
             }
 
             hm_i = s_hm_i;
-            hm[(int) hm_i] = (16u)t;
+            hm[hm_i] = (16u)t;
             hm_i += 1;
             s_hm_i = hm_i;
 

--- a/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/test.jazz
+++ b/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/test.jazz
@@ -15,7 +15,7 @@ fn __decode_public_key_external(reg u64 h pk) -> reg u32 {
 
     i = 0;
     while(i < ARRAY_N){
-        (u16)[h + 2 * i] = h_buff[(int) i];
+        (u16)[h + 2 * i] = h_buff[i];
         i += 1;
     }
 
@@ -35,7 +35,7 @@ fn __decode_sign_external(reg u64 sign esign sign_len) -> reg u32 {
 
     i = 0;
     while(i < ARRAY_N){
-        (u16)[sign + 2 * i] = sign_buff[(int) i];
+        (u16)[sign + 2 * i] = sign_buff[i];
         i += 1;
     }
 
@@ -71,7 +71,7 @@ fn __shake256_absorb_external(reg u64 state in inlen){
 
     i = 0;
     while(i < 25){
-        [state + 8 * i] = state_buff[(int) i];
+        [state + 8 * i] = state_buff[i];
         i += 1;
     }
 
@@ -136,8 +136,8 @@ fn __sub_canonical_external(reg u64 des src1 src2){
 
     i = 0;
     while(i < ARRAY_N){
-        buff1[(int) i] = (u16)[src1 + 2 * i];
-        buff2[(int) i] = (u16)[src2 + 2 * i];
+        buff1[i] = (u16)[src1 + 2 * i];
+        buff2[i] = (u16)[src2 + 2 * i];
         i += 1;
     }
 
@@ -145,7 +145,7 @@ fn __sub_canonical_external(reg u64 des src1 src2){
 
     i = 0;
     while(i < ARRAY_N){
-        (u16)[des + 2 * i] = buff3[(int) i];
+        (u16)[des + 2 * i] = buff3[i];
         i += 1;
     }
 
@@ -161,8 +161,8 @@ fn __is_short_external(reg u64 s1 s2) -> reg u32 {
 
     i = 0;
     while(i < ARRAY_N){
-        buff1[(int) i] = (u16)[s1 + 2 * i];
-        buff2[(int) i] = (u16)[s2 + 2 * i];
+        buff1[i] = (u16)[s1 + 2 * i];
+        buff2[i] = (u16)[s2 + 2 * i];
         i += 1;
     }
 
@@ -180,9 +180,9 @@ fn __verify_raw_external(reg u64 c0 s2 h) -> reg u32 {
 
     i = 0;
     while(i < ARRAY_N){
-        buff1[(int) i] = (u16)[c0 + 2 * i];
-        buff2[(int) i] = (u16)[s2 + 2 * i];
-        buff3[(int) i] = (u16)[h + 2 * i];
+        buff1[i] = (u16)[c0 + 2 * i];
+        buff2[i] = (u16)[s2 + 2 * i];
+        buff3[i] = (u16)[h + 2 * i];
         i += 1;
     }
 

--- a/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/vec.jinc
+++ b/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/vec.jinc
@@ -13,13 +13,13 @@ fn __load4_u256(reg u256 buff0 buff1 buff2 buff3, stack u16[ARRAY_N] src, reg u6
     reg u64 __src_indx;
 
     __src_indx = src_indx;
-    buff0 = src.[u256 (int) __src_indx];
+    buff0 = src.[u256 __src_indx];
     __src_indx += jump;
-    buff1 = src.[u256 (int) __src_indx];
+    buff1 = src.[u256 __src_indx];
     __src_indx += jump;
-    buff2 = src.[u256 (int) __src_indx];
+    buff2 = src.[u256 __src_indx];
     __src_indx += jump;
-    buff3 = src.[u256 (int) __src_indx];
+    buff3 = src.[u256 __src_indx];
 
     return buff0, buff1, buff2, buff3;
 
@@ -31,13 +31,13 @@ fn __store4_u256(reg u256 buff0 buff1 buff2 buff3, stack u16[ARRAY_N] des, reg u
     reg u64 __des_indx;
 
     __des_indx = des_indx;
-    des.[u256 (int) __des_indx] = buff0;
+    des.[u256 __des_indx] = buff0;
     __des_indx += jump;
-    des.[u256 (int) __des_indx] = buff1;
+    des.[u256 __des_indx] = buff1;
     __des_indx += jump;
-    des.[u256 (int) __des_indx] = buff2;
+    des.[u256 __des_indx] = buff2;
     __des_indx += jump;
-    des.[u256 (int) __des_indx] = buff3;
+    des.[u256 __des_indx] = buff3;
 
     return des;
 
@@ -61,8 +61,8 @@ fn __sub_canonical(stack u16[ARRAY_N] des src1 src2) -> stack u16[ARRAY_N] {
     i = 0;
     while(i < ARRAY_N * 2){
 
-        t0 = src1.[u256 (int) i];
-        t1 = src2.[u256 (int) i];
+        t0 = src1.[u256 i];
+        t1 = src2.[u256 i];
 
         t0 = #VPSUB_16u16(t0, t1);
 
@@ -78,7 +78,7 @@ fn __sub_canonical(stack u16[ARRAY_N] des src1 src2) -> stack u16[ARRAY_N] {
         cmpn = #VPMULL_16u16(cmpn, __q);
         t0 = #VPSUB_16u16(t0, cmpn);
 
-        des.[u256 (int) i] = t0;
+        des.[u256 i] = t0;
 
         i += 32;
 

--- a/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/verify.jinc
+++ b/oldsrc-should-delete/crypto_sign/falcon/falcon512/amd64/avx2/verify.jinc
@@ -15,7 +15,7 @@ fn __verify_raw(stack u16[ARRAY_N] c0 s2 h) -> reg u32 {
 
     i = 0;
     while(i < ARRAY_N){
-        buff2[(int) i] = s2[(int) i];
+        buff2[i] = s2[i];
         i += 1;
     }
 

--- a/oldsrc-should-delete/crypto_sign/falcon/falcon512/common/amd64/common.jinc
+++ b/oldsrc-should-delete/crypto_sign/falcon/falcon512/common/amd64/common.jinc
@@ -14,14 +14,14 @@ fn __is_short(stack u16[ARRAY_N] s1 s2) -> reg u32
   i = 0;
   while(i < ARRAY_N)
   {
-    z = (32s)s1[(int)i];
+    z = (32s)s1[i];
     t = z;
     t *= z;
     s += t;
     s = s;
     ng |= s;
 
-    z = (32s)s2[(int)i];
+    z = (32s)s2[i];
     t = z;
     t *= z;
     s += t;

--- a/oldsrc-should-delete/crypto_sign/falcon/falcon512/common/amd64/encode_decode.jinc
+++ b/oldsrc-should-delete/crypto_sign/falcon/falcon512/common/amd64/encode_decode.jinc
@@ -213,7 +213,7 @@ fn __comp_decode(stack u16[ARRAY_N] out, reg u64 in, reg u64 max_in_len)
             }
             m = -m;
         }
-        out[(int) out_i] = m;
+        out[out_i] = m;
         out_i += 1;
     }
 

--- a/oldsrc-should-delete/crypto_sign/falcon/falcon512/common/amd64/shake256.jinc
+++ b/oldsrc-should-delete/crypto_sign/falcon/falcon512/common/amd64/shake256.jinc
@@ -43,7 +43,7 @@ fn __shake256_squeezeblock(stack u64[25] state, reg ptr u8[SHAKE256_RATE] out) -
   out = s_out;
 
   for i = 0 to SHAKE256_RATE {
-    c = state[u8 (int) i];
+    c = state[u8 i];
     out[i] = c;
   }
 

--- a/oldsrc-should-delete/crypto_stream/chacha/common/amd64/ref/chacha_store.jinc
+++ b/oldsrc-should-delete/crypto_stream/chacha/common/amd64/ref/chacha_store.jinc
@@ -140,7 +140,7 @@ inline fn __store_xor_last_ref(stack u64 s_output s_input s_len, reg u32[16] k, 
   while(j < len8)
   {
     t = (u64)[input + 8*j];
-    t ^= s_k[u64 (int)j];
+    t ^= s_k[u64 j];
     (u64)[output + 8*j] = t;
     j += 1;
   }
@@ -150,7 +150,7 @@ inline fn __store_xor_last_ref(stack u64 s_output s_input s_len, reg u32[16] k, 
   while(j < len)
   {
     pi = (u8)[input + j];
-    pi ^= s_k[u8 (int)j];
+    pi ^= s_k[u8 j];
     (u8)[output + j] = pi;
     j += 1;
   }
@@ -284,7 +284,7 @@ inline fn __store_last_ref(stack u64 s_output s_len, reg u32[16] k, stack u32 k1
   j = 0;
   while(j < len8)
   {
-    t = s_k[u64 (int)j];
+    t = s_k[u64 j];
     (u64)[output + 8*j] = t;
     j += 1;
   }
@@ -293,7 +293,7 @@ inline fn __store_last_ref(stack u64 s_output s_len, reg u32[16] k, stack u32 k1
   // u8 at a time
   while(j < len)
   {
-    pi = s_k[u8 (int)j];
+    pi = s_k[u8 j];
     (u8)[output + j] = pi;
     j += 1;
   }


### PR DESCRIPTION
Remove redundant casts to int in array accesses and use the `BLENDV` intrinsic instead of the deprecated `VPBLENDVB`.